### PR TITLE
#54: 크롤링 봇 차단

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -18,5 +18,4 @@ User-agent: CCBot
 User-agent: Pinterestbot
 User-agent: GPTBot
 User-agent: PerplexityBot
-User-agent: Pinterest
 Disallow: /

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,6 @@
+# ref: https://searchengineland.com/a-deeper-look-at-robotstxt-17573
+
+# 특정 디렉토리의 접근 차단
 User-agent: *
 Disallow: /api
 Disallow: /login
@@ -5,14 +8,9 @@ Disallow: /logout
 Disallow: /register
 Disallow: /settings
 
-User-agent: CCBot
-Disallow: /
-
-User-agent: Pinterestbot
-Disallow: /
-
-User-agent: GPTBot
-Disallow: /
-
-User-agent: PerplexityBot
+# AI 학습용 봇 차단
+User-agent: CCBot           # https://commoncrawl.org/ccbot
+User-agent: Pinterestbot    # https://help.pinterest.com/ko/business/article/pinterestbot
+User-agent: GPTBot          # https://platform.openai.com/docs/bots
+User-agent: PerplexityBot   # https://docs.perplexity.ai/guides/bots
 Disallow: /

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -2,7 +2,7 @@
 
 # 특정 디렉토리의 접근 차단
 User-agent: *
-Disallow: /api
+Disallow: /api          # /api/file 도 차단되므로, 이미지 수집도 차단됨
 Disallow: /login
 Disallow: /logout
 Disallow: /register

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,18 @@
+User-agent: *
+Disallow: /api
+Disallow: /login
+Disallow: /logout
+Disallow: /register
+Disallow: /settings
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Pinterestbot
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,16 +1,22 @@
 # ref: https://searchengineland.com/a-deeper-look-at-robotstxt-17573
 
 # 특정 디렉토리의 접근 차단
+# 참고: /api/file 도 차단되므로, 이미지 수집도 차단됨
 User-agent: *
-Disallow: /api          # /api/file 도 차단되므로, 이미지 수집도 차단됨
+Disallow: /api
 Disallow: /login
 Disallow: /logout
 Disallow: /register
 Disallow: /settings
 
 # AI 학습용 봇 차단
-User-agent: CCBot           # https://commoncrawl.org/ccbot
-User-agent: Pinterestbot    # https://help.pinterest.com/ko/business/article/pinterestbot
-User-agent: GPTBot          # https://platform.openai.com/docs/bots
-User-agent: PerplexityBot   # https://docs.perplexity.ai/guides/bots
+# ref: https://commoncrawl.org/ccbot
+# ref: https://help.pinterest.com/ko/business/article/pinterestbot
+# ref: https://platform.openai.com/docs/bots
+# ref: https://docs.perplexity.ai/guides/bots
+User-agent: CCBot
+User-agent: Pinterestbot
+User-agent: GPTBot
+User-agent: PerplexityBot
+User-agent: Pinterest
 Disallow: /


### PR DESCRIPTION
- resolves #54
  - 다음의 크롤링 봇을 차단하여 AI 학습 방해
    - CCBot
    - Pinterestbot
    - GPTBot
    - PerplexityBot
  - 전체 UA에 대해 특정 디렉토리의 수집 차단