### PR TITLE
#80: 기본 DM 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "wtda",
 	"private": true,
-	"version": "0.0.1",
+	"version": "0.1.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev --host",
@@ -89,6 +89,7 @@
 		"@aws-sdk/client-s3": "^3.808.0",
 		"@aws-sdk/client-sesv2": "^3.817.0",
 		"@internationalized/date": "^3.8.1",
+		"@microsoft/fetch-event-source": "^2.0.1",
 		"@node-rs/argon2": "^2.0.2",
 		"@oslojs/crypto": "^1.0.1",
 		"@oslojs/encoding": "^1.1.0",
@@ -109,6 +110,7 @@
 		"svelte-awesome-color-picker": "^4.0.1",
 		"svelte-crop-window": "^0.1.1",
 		"svelte-file-dropzone": "^2.0.9",
+		"sveltekit-sse": "^0.13.19",
 		"tinycolor2": "^1.6.0",
 		"twemoji-svelte-action": "^1.0.5"
 	},

--- a/src/app.ts
+++ b/src/app.ts
@@ -94,6 +94,8 @@ declare global {
 					type: 'join' | 'leave';
 			  }
 		);
+
+		type DMChannel = import('$lib/server/common/dm').DMChannelInfo;
 	}
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,10 @@ declare global {
 		NumberEnumerate<F>
 	>;
 
+	type Nullish<T> = T | undefined | null;
+	type Nullable<T> = T | null;
+	type Optional<T> = T | undefined;
+
 	namespace App {
 		interface Error {
 			code?: ErrorCode;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -82,3 +82,4 @@ export const imageMime = [
 export const announcementsPerPage = 5;
 export const searchResultsPerPage = 10;
 export const profileArticlesPerPage = 10;
+export const dmsPerPage = 20;

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -2,7 +2,7 @@ import { DMChannelType, UserRelationship } from '@app';
 import { db, generateID, table } from '../db';
 import { and, desc, eq, lte, max, SQL, Subquery } from 'drizzle-orm';
 import { getRelationship } from './relationship';
-import { intersect, union } from 'drizzle-orm/pg-core';
+import { alias, intersect, union } from 'drizzle-orm/pg-core';
 import type { DMChannel, dmChannel, DMParticipant, User } from '../db/schema';
 import { message } from 'sveltekit-superforms';
 
@@ -82,18 +82,20 @@ export const getDMChannels = async (
 			sentAt: latestMessage.sentAt,
 			content: table.dmContent.content,
 			messageId: table.dmContent.messageId,
-			sender: table.user,
+			sender: { ...table.user },
 		})
 		.from(table.dmParticipant)
 		.where(eq(table.dmParticipant.participantId, fromUser))
 		.innerJoin(latestMessage, eq(latestMessage.channelId, table.dmParticipant.channelId))
 		.innerJoin(table.dmContent, eq(table.dmContent.sentAt, latestMessage.sentAt))
-		.innerJoin(table.user, eq(table.dmContent.sender, table.user.id))
+		.innerJoin(table.user, eq(table.user.id, table.dmContent.sender))
 		.as('sq');
 
 	let subquery = toUser
 		? intersect(userQuery(fromUser), userQuery(toUser)).as('sq')
 		: userWithLatestMessage;
+
+	const participant = alias(table.user, 'participant');
 
 	const rows = await db
 		.select({
@@ -113,7 +115,7 @@ export const getDMChannels = async (
 						},
 						latestMessageSender: userWithLatestMessage.sender,
 						participant: {
-							...table.user,
+							...participant,
 							id: table.dmParticipant.participantId,
 						},
 					}
@@ -123,7 +125,7 @@ export const getDMChannels = async (
 		.where(additionalWhere?.(subquery, table.dmChannel))
 		.innerJoin(table.dmChannel, eq(table.dmChannel.id, subquery.channelId))
 		.innerJoin(table.dmParticipant, eq(table.dmParticipant.channelId, subquery.channelId))
-		.innerJoin(table.user, eq(table.user.id, table.dmParticipant.participantId));
+		.innerJoin(participant, eq(participant.id, table.dmParticipant.participantId));
 
 	const result = rows.reduce<
 		Record<DMChannel['id'], DMChannel & { participants: User[]; latestMessage?: App.DM }>

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -8,6 +8,7 @@ import {
 	eq,
 	lte,
 	max,
+	ne,
 	sql,
 	SQL,
 	Subquery,
@@ -354,6 +355,57 @@ export const get = async (channelId: string, before: Date, me: NonNullable<App.U
 	}));
 };
 
+const relationshipToUser = alias(table.userRelationship, 'relationshipToUser');
+const relationshipFromUser = alias(table.userRelationship, 'relationshipFromUser');
+
+const ableToSendSubquery = db
+	.select({
+		participant: table.dmParticipant.participantId,
+		relationshipToUser: relationshipToUser.to,
+		relationshipFromUser: relationshipFromUser.from,
+	})
+	.from(table.dmParticipant)
+	.where(
+		and(
+			eq(table.dmParticipant.channelId, sql.placeholder('channelId')),
+			ne(table.dmParticipant.participantId, sql.placeholder('senderId')),
+		),
+	)
+	.leftJoin(
+		relationshipToUser,
+		and(
+			eq(relationshipToUser.from, sql.placeholder('senderId')),
+			eq(relationshipToUser.to, table.dmParticipant.participantId),
+		),
+	)
+	.leftJoin(
+		relationshipFromUser,
+		and(
+			eq(relationshipFromUser.to, sql.placeholder('senderId')),
+			eq(relationshipFromUser.from, table.dmParticipant.participantId),
+		),
+	)
+	.as('sq');
+
+const ableToSendQuery = db
+	.select()
+	.from(ableToSendSubquery)
+	.where(
+		and(
+			ne(ableToSendSubquery.relationshipFromUser, UserRelationship.BLOCKED),
+			ne(ableToSendSubquery.relationshipToUser, UserRelationship.BLOCKED),
+		),
+	);
+
+export const isAbleToSend = async (channelId: string, sender: NonNullable<App.User>) => {
+	const result = await ableToSendQuery.execute({
+		channelId,
+		senderId: sender.id,
+	});
+
+	return result.length > 0;
+};
+
 export const send = async (
 	channelId: string,
 	sender: NonNullable<App.User>,
@@ -362,6 +414,8 @@ export const send = async (
 ) => {
 	const messageId = generateID();
 	const sentAt = new Date();
+
+	if (!(await isAbleToSend(channelId, sender))) throw Error('Not able to send', { cause: 406 });
 
 	const _relatedMessage = await db.transaction(async (tx) => {
 		await tx.insert(table.dmContent).values({

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -20,6 +20,7 @@ import { message } from 'sveltekit-superforms';
 import { string } from 'zod';
 import type { PostgresJsQueryResultHKT } from 'drizzle-orm/postgres-js';
 import type { Emoji } from 'emoji-type';
+import { dmsPerPage } from '$lib/config';
 
 type Transaction =
 	| PgTransaction<
@@ -267,22 +268,24 @@ export const get = async (channelId: string, before: Date, me: NonNullable<App.U
 	const metadata = db
 		.select({
 			id: table.dmContent.messageId,
+			sentAt: table.dmContent.sentAt,
 			reactions: sql<(typeof reactions)[]>`json_agg(reactions)`.as('reactions'),
 		})
 		.from(table.dmContent)
 		// 참고: sql.placeholder는 Date 형식에 대해 사용 불가하여 현행 유지
 		.where(and(eq(table.dmContent.channelId, channelId), lte(table.dmContent.sentAt, before)))
 		.leftJoin(reactions, eq(reactions.messageId, table.dmContent.messageId))
-		.groupBy((t) => t.id)
+		.groupBy((t) => [t.id, t.sentAt])
+		.orderBy((t) => desc(t.sentAt))
+		.limit(dmsPerPage)
 		.as('metadata');
-	// TODO: 일정 범위 이내의 값만 가져오도록 변경
 
 	const result = await db
 		.select({
 			id: metadata.id,
 			sender: table.user,
 			content: table.dmContent.content,
-			sentAt: table.dmContent.sentAt,
+			sentAt: metadata.sentAt,
 			relatedMessage: {
 				id: rmContent.messageId,
 				content: rmContent.content,
@@ -317,16 +320,18 @@ export const get = async (channelId: string, before: Date, me: NonNullable<App.U
 		.orderBy((t) => asc(t.sentAt));
 
 	// 읽음 확인
-	await db
-		.insert(table.dmReceived)
-		.values(
-			result.map((message) => ({
-				channelId,
-				messageId: message.id,
-				receiver: me.id,
-			})),
-		)
-		.onConflictDoNothing();
+	if (result.length > 0) {
+		await db
+			.insert(table.dmReceived)
+			.values(
+				result.map((message) => ({
+					channelId,
+					messageId: message.id,
+					receiver: me.id,
+				})),
+			)
+			.onConflictDoNothing();
+	}
 
 	return result.map<App.DM>((v) => ({
 		id: v.id,

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -19,8 +19,7 @@ import {
 import { getRelationship } from './relationship';
 import { alias, intersect, PgTransaction, union } from 'drizzle-orm/pg-core';
 import type { DMChannel, dmChannel, DMParticipant, User } from '../db/schema';
-import { message } from 'sveltekit-superforms';
-import { string } from 'zod';
+import * as telecom from './telecom';
 import type { PostgresJsQueryResultHKT } from 'drizzle-orm/postgres-js';
 import type { Emoji } from 'emoji-type';
 import { dmsPerPage } from '$lib/config';
@@ -489,7 +488,7 @@ export const send = async (
 		);
 	});
 
-	return [
+	const dms = [
 		{
 			id: messageId,
 			sender: sender,
@@ -503,6 +502,18 @@ export const send = async (
 			},
 		},
 	];
+
+	(
+		await db
+			.select({ uid: table.dmParticipant.participantId })
+			.from(table.dmParticipant)
+			.where(eq(table.dmParticipant.channelId, channelId))
+	).forEach(({ uid }) => {
+		console.log(`>> notify to ${uid}`);
+		telecom.notify(uid, dms);
+	});
+
+	return dms;
 };
 
 // ref: https://orm.drizzle.team/docs/perf-queries#placeholder

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -2,7 +2,7 @@ import { DMChannelType, UserRelationship } from '@app';
 import { db, generateID, table } from '../db';
 import { and, desc, eq, max, SQL, Subquery } from 'drizzle-orm';
 import { getRelationship } from './relationship';
-import { union } from 'drizzle-orm/pg-core';
+import { intersect, union } from 'drizzle-orm/pg-core';
 import type { DMChannel, dmChannel, DMParticipant, User } from '../db/schema';
 import { message } from 'sveltekit-superforms';
 
@@ -72,20 +72,28 @@ export const getDMChannels = async (
 		db
 			.select({
 				channelId: table.dmParticipant.channelId,
-				sentAt: latestMessage.sentAt,
-				content: table.dmContent.content,
-				messageId: table.dmContent.messageId,
-				sender: table.user,
 			})
 			.from(table.dmParticipant)
-			.where(eq(table.dmParticipant.participantId, userId))
-			.innerJoin(latestMessage, eq(latestMessage.channelId, table.dmParticipant.channelId))
-			.innerJoin(table.dmContent, eq(table.dmContent.sentAt, latestMessage.sentAt))
-			.innerJoin(table.user, eq(table.dmContent.sender, table.user.id));
+			.where(eq(table.dmParticipant.participantId, userId));
 
-	const fromUserQuery = userQuery(fromUser);
+	const userWithLatestMessage = db
+		.select({
+			channelId: table.dmParticipant.channelId,
+			sentAt: latestMessage.sentAt,
+			content: table.dmContent.content,
+			messageId: table.dmContent.messageId,
+			sender: table.user,
+		})
+		.from(table.dmParticipant)
+		.where(eq(table.dmParticipant.participantId, fromUser))
+		.innerJoin(latestMessage, eq(latestMessage.channelId, table.dmParticipant.channelId))
+		.innerJoin(table.dmContent, eq(table.dmContent.sentAt, latestMessage.sentAt))
+		.innerJoin(table.user, eq(table.dmContent.sender, table.user.id))
+		.as('sq');
 
-	let subquery = (toUser ? union(fromUserQuery, userQuery(toUser)) : fromUserQuery).as('sq');
+	let subquery = toUser
+		? intersect(userQuery(fromUser), userQuery(toUser)).as('sq')
+		: userWithLatestMessage;
 
 	const rows = await db
 		.select({
@@ -96,16 +104,20 @@ export const getDMChannels = async (
 				createdDate: table.dmChannel.createdDate,
 				closedDate: table.dmChannel.closedDate,
 			},
-			latestMessage: {
-				sentAt: subquery.sentAt,
-				content: subquery.content,
-				messageId: subquery.messageId,
-			},
-			latestMessageSender: subquery.sender,
-			participant: {
-				...table.user,
-				id: table.dmParticipant.participantId,
-			},
+			...(!toUser
+				? {
+						latestMessage: {
+							sentAt: userWithLatestMessage.sentAt,
+							content: userWithLatestMessage.content,
+							messageId: userWithLatestMessage.messageId,
+						},
+						latestMessageSender: userWithLatestMessage.sender,
+						participant: {
+							...table.user,
+							id: table.dmParticipant.participantId,
+						},
+					}
+				: {}),
 		})
 		.from(subquery)
 		.where(additionalWhere?.(subquery, table.dmChannel))
@@ -114,7 +126,7 @@ export const getDMChannels = async (
 		.innerJoin(table.user, eq(table.user.id, table.dmParticipant.participantId));
 
 	const result = rows.reduce<
-		Record<DMChannel['id'], DMChannel & { participants: User[]; latestMessage: App.DM }>
+		Record<DMChannel['id'], DMChannel & { participants: User[]; latestMessage?: App.DM }>
 	>((acc, row) => {
 		const channel = row.channel;
 		const participant = row.participant;
@@ -123,10 +135,10 @@ export const getDMChannels = async (
 			acc[channel.id] = {
 				...channel,
 				participants: [],
-				latestMessage: {
+				latestMessage: row.latestMessage && {
 					id: row.latestMessage.messageId,
 					sentAt: row.latestMessage.sentAt || new Date(),
-					sender: row.latestMessageSender,
+					sender: row.latestMessageSender || null,
 					...row.latestMessage.content,
 				},
 			};
@@ -162,12 +174,7 @@ export const beginDMProc = async (
 	// 이미 채널이 있는 경우 해당 채널의 ID 반환
 	const result = (
 		await getDMChannels(fromUser, toUser, (_, ch) =>
-			type === DMChannelType.GENERAL
-				? eq(ch.type, type)
-				: and(
-						eq(ch.type, type),
-						relatedArticle ? eq(ch.relatedArticle, relatedArticle) : undefined,
-					),
+			and(eq(ch.type, type), relatedArticle ? eq(ch.relatedArticle, relatedArticle) : undefined),
 		)
 	).at(0);
 	if (result) return result.id;

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -1,6 +1,6 @@
 import { DMChannelType, UserRelationship } from '@app';
 import { db, generateID, table } from '../db';
-import { and, desc, eq, max, SQL, Subquery } from 'drizzle-orm';
+import { and, desc, eq, lte, max, SQL, Subquery } from 'drizzle-orm';
 import { getRelationship } from './relationship';
 import { intersect, union } from 'drizzle-orm/pg-core';
 import type { DMChannel, dmChannel, DMParticipant, User } from '../db/schema';
@@ -214,4 +214,23 @@ export const getDMChannelInfo = async (channelId: string) => {
 
 export type DMChannelInfo = Awaited<ReturnType<typeof getDMChannelInfo>>;
 
-export const getDMLists = async (before: Date) => {};
+export const get = async (channelId: string, before: Date) => {
+	const result = await db
+		.select({
+			id: table.dmContent.messageId,
+			sender: table.user,
+			content: table.dmContent.content,
+			sentAt: table.dmContent.sentAt,
+		})
+		.from(table.dmContent)
+		.where(and(eq(table.dmContent.channelId, channelId), lte(table.dmContent.sentAt, before)))
+		.innerJoin(table.user, eq(table.user.id, table.dmContent.sender));
+	// TODO: 일정 범위 이내의 값만 가져오도록 변경
+
+	return result.map<App.DM>((v) => ({
+		id: v.id,
+		sender: v.sender,
+		sentAt: v.sentAt,
+		...v.content,
+	}));
+};

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -509,8 +509,7 @@ export const send = async (
 			.from(table.dmParticipant)
 			.where(eq(table.dmParticipant.channelId, channelId))
 	).forEach(({ uid }) => {
-		console.log(`>> notify to ${uid}`);
-		telecom.notify(uid, { channelId, dms });
+		telecom.notify(uid, { event: 'dmSent', channelId, dms });
 	});
 
 	return dms;

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -6,9 +6,11 @@ import {
 	count,
 	desc,
 	eq,
+	isNull,
 	lte,
 	max,
 	ne,
+	or,
 	sql,
 	SQL,
 	Subquery,
@@ -159,8 +161,6 @@ export const getDMChannels = async (
 		.innerJoin(table.dmChannel, eq(table.dmChannel.id, subquery.channelId))
 		.innerJoin(table.dmParticipant, eq(table.dmParticipant.channelId, subquery.channelId))
 		.innerJoin(participant, eq(participant.id, table.dmParticipant.participantId));
-
-	console.log(rows);
 
 	const result = rows.reduce<
 		Record<
@@ -404,8 +404,14 @@ const ableToSendQuery = db
 	.from(ableToSendSubquery)
 	.where(
 		and(
-			ne(ableToSendSubquery.relationshipFromUser, UserRelationship.BLOCKED),
-			ne(ableToSendSubquery.relationshipToUser, UserRelationship.BLOCKED),
+			or(
+				isNull(ableToSendSubquery.relationshipFromUser),
+				ne(ableToSendSubquery.relationshipFromUser, UserRelationship.BLOCKED),
+			),
+			or(
+				isNull(ableToSendSubquery.relationshipToUser),
+				ne(ableToSendSubquery.relationshipToUser, UserRelationship.BLOCKED),
+			),
 		),
 	);
 

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -269,6 +269,7 @@ export const get = async (channelId: string, before: Date, me: NonNullable<App.U
 			reactions: sql<(typeof reactions)[]>`json_agg(reactions)`.as('reactions'),
 		})
 		.from(table.dmContent)
+		// 참고: sql.placeholder는 Date 형식에 대해 사용 불가하여 현행 유지
 		.where(and(eq(table.dmContent.channelId, channelId), lte(table.dmContent.sentAt, before)))
 		.leftJoin(reactions, eq(reactions.messageId, table.dmContent.messageId))
 		.groupBy((t) => t.id)

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -227,7 +227,7 @@ export const beginDMProc = async (
 	});
 };
 
-export const getDMChannelInfo = async (channelId: string) => {
+export const getDMChannelInfo = async (channelId: string, sender: NonNullable<App.User>) => {
 	const channelInfo = (
 		await db
 			.select({
@@ -246,7 +246,11 @@ export const getDMChannelInfo = async (channelId: string) => {
 		.where(eq(table.dmParticipant.channelId, channelId))
 		.innerJoin(table.user, eq(table.user.id, table.dmParticipant.participantId));
 
-	return { ...channelInfo, participants: participants.map((v) => v.participant) };
+	return {
+		...channelInfo,
+		participants: participants.map((v) => v.participant),
+		isAbleToSend: await isAbleToSend(channelId, sender),
+	};
 };
 
 export type DMChannelInfo = Awaited<ReturnType<typeof getDMChannelInfo>>;

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -23,6 +23,7 @@ import * as telecom from './telecom';
 import type { PostgresJsQueryResultHKT } from 'drizzle-orm/postgres-js';
 import type { Emoji } from 'emoji-type';
 import { dmsPerPage } from '$lib/config';
+import { aliasedColumn } from '../db/shorthands';
 
 type Transaction =
 	| PgTransaction<
@@ -372,8 +373,8 @@ const relationshipFromUser = alias(table.userRelationship, 'relationshipFromUser
 const ableToSendSubquery = db
 	.select({
 		participant: table.dmParticipant.participantId,
-		relationshipToUser: relationshipToUser.to,
-		relationshipFromUser: relationshipFromUser.from,
+		relationshipToUser: aliasedColumn(relationshipToUser.relationship, 'relationshipToUser'),
+		relationshipFromUser: aliasedColumn(relationshipFromUser.relationship, 'relationshipFromUser'),
 	})
 	.from(table.dmParticipant)
 	.where(

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -189,3 +189,29 @@ export const beginDMProc = async (
 	// 해당 채널 ID를 반환
 	return channelId;
 };
+
+export const getDMChannelInfo = async (channelId: string) => {
+	const channelInfo = (
+		await db
+			.select({
+				type: table.dmChannel.type,
+				relatedArticle: table.dmChannel.relatedArticle,
+			})
+			.from(table.dmChannel)
+			.where(eq(table.dmChannel.id, channelId))
+	).at(0);
+
+	const participants = await db
+		.select({
+			participant: table.user,
+		})
+		.from(table.dmParticipant)
+		.where(eq(table.dmParticipant.channelId, channelId))
+		.innerJoin(table.user, eq(table.user.id, table.dmParticipant.participantId));
+
+	return { ...channelInfo, participants: participants.map((v) => v.participant) };
+};
+
+export type DMChannelInfo = Awaited<ReturnType<typeof getDMChannelInfo>>;
+
+export const getDMLists = async (before: Date) => {};

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -5,6 +5,7 @@ import { getRelationship } from './relationship';
 import { alias, intersect, union } from 'drizzle-orm/pg-core';
 import type { DMChannel, dmChannel, DMParticipant, User } from '../db/schema';
 import { message } from 'sveltekit-superforms';
+import { string } from 'zod';
 
 export const createDMChannel = async (type = DMChannelType.GENERAL, relatedArticle?: string) => {
 	const channelId = generateID();
@@ -217,16 +218,33 @@ export const getDMChannelInfo = async (channelId: string) => {
 export type DMChannelInfo = Awaited<ReturnType<typeof getDMChannelInfo>>;
 
 export const get = async (channelId: string, before: Date) => {
+	const rmContent = alias(table.dmContent, 'rm_content');
+	const rmSender = alias(table.user, 'rm_sender');
+
 	const result = await db
 		.select({
 			id: table.dmContent.messageId,
 			sender: table.user,
 			content: table.dmContent.content,
 			sentAt: table.dmContent.sentAt,
+			relatedMessage: {
+				id: rmContent.messageId,
+				content: rmContent.content,
+				sentAt: rmContent.sentAt,
+			},
+			relatedMessageSender: rmSender,
 		})
 		.from(table.dmContent)
 		.where(and(eq(table.dmContent.channelId, channelId), lte(table.dmContent.sentAt, before)))
-		.innerJoin(table.user, eq(table.user.id, table.dmContent.sender));
+		.innerJoin(table.user, eq(table.user.id, table.dmContent.sender))
+		.leftJoin(
+			rmContent,
+			and(
+				eq(rmContent.channelId, table.dmContent.channelId),
+				eq(rmContent.messageId, table.dmContent.relatedMessage),
+			),
+		)
+		.leftJoin(rmSender, eq(rmSender.id, rmContent.sender));
 	// TODO: 일정 범위 이내의 값만 가져오도록 변경
 
 	return result.map<App.DM>((v) => ({
@@ -234,6 +252,14 @@ export const get = async (channelId: string, before: Date) => {
 		sender: v.sender,
 		sentAt: v.sentAt,
 		...v.content,
+		relatedMessage:
+			(v.relatedMessage && {
+				id: v.relatedMessage.id,
+				sender: v.relatedMessageSender,
+				sentAt: v.relatedMessage.sentAt,
+				...v.relatedMessage.content,
+			}) ||
+			undefined,
 	}));
 };
 
@@ -241,6 +267,7 @@ export const send = async (
 	channelId: string,
 	sender: NonNullable<App.User>,
 	content: Omit<App.DM, 'id' | 'sentAt' | 'sender'>,
+	relatedMessage?: string,
 ) => {
 	const messageId = generateID();
 	const sentAt = new Date();
@@ -251,14 +278,42 @@ export const send = async (
 		sender: sender.id,
 		content,
 		sentAt,
+		relatedMessage,
 	});
+
+	const _relatedMessage =
+		(relatedMessage &&
+			(
+				await db
+					.select({
+						id: table.dmContent.messageId,
+						sender: table.user,
+						content: table.dmContent.content,
+						sentAt: table.dmContent.sentAt,
+					})
+					.from(table.dmContent)
+					.where(
+						and(
+							eq(table.dmContent.channelId, channelId),
+							eq(table.dmContent.messageId, relatedMessage),
+						),
+					)
+					.innerJoin(table.user, eq(table.user.id, table.dmContent.sender))
+			).at(0)) ||
+		undefined;
 
 	return [
 		{
 			id: messageId,
 			sender: sender,
-			sentAt: sentAt,
+			sentAt,
 			...content,
+			relatedMessage: _relatedMessage && {
+				id: _relatedMessage.id,
+				sender: _relatedMessage.sender,
+				sentAt: _relatedMessage.sentAt,
+				..._relatedMessage.content,
+			},
 		},
 	];
 };

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -3,6 +3,7 @@ import { db, generateID, table } from '../db';
 import { and, eq, SQL, Subquery } from 'drizzle-orm';
 import { getRelationship } from './relationship';
 import { union } from 'drizzle-orm/pg-core';
+import type { DMChannel, dmChannel, DMParticipant, User } from '../db/schema';
 
 export const createDMChannel = async (type = DMChannelType.GENERAL, relatedArticle?: string) => {
 	const channelId = generateID();
@@ -74,17 +75,44 @@ export const getDMChannels = async (
 			: fromUserQuery
 	).as('sq');
 
-	return await db
+	const rows = await db
 		.select({
-			id: subquery.channelId,
-			type: table.dmChannel.type,
-			relatedArticle: table.dmChannel.relatedArticle,
-			createdDate: table.dmChannel.createdDate,
-			closedDate: table.dmChannel.closedDate,
+			channel: {
+				id: subquery.channelId,
+				type: table.dmChannel.type,
+				relatedArticle: table.dmChannel.relatedArticle,
+				createdDate: table.dmChannel.createdDate,
+				closedDate: table.dmChannel.closedDate,
+			},
+			participant: {
+				...table.user,
+				id: table.dmParticipant.participantId,
+			},
 		})
 		.from(subquery)
 		.where(additionalWhere?.(subquery, table.dmChannel))
-		.innerJoin(table.dmChannel, eq(table.dmChannel.id, subquery.channelId));
+		.innerJoin(table.dmChannel, eq(table.dmChannel.id, subquery.channelId))
+		.innerJoin(table.dmParticipant, eq(table.dmParticipant.channelId, subquery.channelId))
+		.innerJoin(table.user, eq(table.user.id, table.dmParticipant.participantId));
+
+	const result = rows.reduce<Record<DMChannel['id'], DMChannel & { participants: User[] }>>(
+		(acc, row) => {
+			const channel = row.channel;
+			const participant = row.participant;
+
+			if (!acc[channel.id]) {
+				acc[channel.id] = { ...channel, participants: [] };
+			}
+
+			if (participant) {
+				acc[channel.id].participants.push(participant);
+			}
+			return acc;
+		},
+		{},
+	);
+
+	return Object.values(result);
 };
 
 export const beginDMProc = async (

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -57,7 +57,7 @@ export const leaveFromChannel = async (userId: string, channelId: string) => {
 export const getDMChannels = async (
 	fromUser: string,
 	toUser?: string,
-	additionalWhere?: (part: Subquery, ch: typeof table.dmChannel) => SQL,
+	additionalWhere?: (part: Subquery, ch: typeof table.dmChannel) => SQL | undefined,
 ) => {
 	const latestMessage = db
 		.select({
@@ -160,7 +160,16 @@ export const beginDMProc = async (
 		throw new Error('Cannot chat with blocked user', { cause: 403 });
 
 	// 이미 채널이 있는 경우 해당 채널의 ID 반환
-	const result = (await getDMChannels(fromUser, toUser, (_, ch) => eq(ch.type, type))).at(0);
+	const result = (
+		await getDMChannels(fromUser, toUser, (_, ch) =>
+			type === DMChannelType.GENERAL
+				? eq(ch.type, type)
+				: and(
+						eq(ch.type, type),
+						relatedArticle ? eq(ch.relatedArticle, relatedArticle) : undefined,
+					),
+		)
+	).at(0);
 	if (result) return result.id;
 
 	// 채널 생성

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -281,6 +281,20 @@ export const send = async (
 		relatedMessage,
 	});
 
+	const attachments =
+		(content.type === 'general' && (content as App.GeneralDM).attachments) || undefined;
+
+	if (attachments)
+		await db.insert(table.filesPerDM).values(
+			attachments
+				.flatMap((v) => [...v.matchAll(/api\/file\/([A-Za-z0-9-\/]+)/g)])
+				.map((path) => ({
+					channelId,
+					messageId,
+					path: path[1],
+				})),
+		);
+
 	const _relatedMessage =
 		(relatedMessage &&
 			(

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -2,6 +2,7 @@ import { DMChannelType, UserRelationship } from '@app';
 import { db, generateID, table } from '../db';
 import {
 	and,
+	asc,
 	count,
 	desc,
 	eq,
@@ -312,7 +313,8 @@ export const get = async (channelId: string, before: Date, me: NonNullable<App.U
 				eq(table.dmReactions.messageId, metadata.id),
 				eq(table.dmReactions.setter, me.id),
 			),
-		);
+		)
+		.orderBy((t) => asc(t.sentAt));
 
 	// 읽음 확인
 	await db

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -234,3 +234,29 @@ export const get = async (channelId: string, before: Date) => {
 		...v.content,
 	}));
 };
+
+export const send = async (
+	channelId: string,
+	sender: NonNullable<App.User>,
+	content: Omit<App.DM, 'id' | 'sentAt' | 'sender'>,
+) => {
+	const messageId = generateID();
+	const sentAt = new Date();
+
+	await db.insert(table.dmContent).values({
+		channelId,
+		messageId,
+		sender: sender.id,
+		content,
+		sentAt,
+	});
+
+	return [
+		{
+			id: messageId,
+			sender: sender,
+			sentAt: sentAt,
+			...content,
+		},
+	];
+};

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -510,7 +510,7 @@ export const send = async (
 			.where(eq(table.dmParticipant.channelId, channelId))
 	).forEach(({ uid }) => {
 		console.log(`>> notify to ${uid}`);
-		telecom.notify(uid, dms);
+		telecom.notify(uid, { channelId, dms });
 	});
 
 	return dms;

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -160,8 +160,13 @@ export const getDMChannels = async (
 		.innerJoin(table.dmParticipant, eq(table.dmParticipant.channelId, subquery.channelId))
 		.innerJoin(participant, eq(participant.id, table.dmParticipant.participantId));
 
+	console.log(rows);
+
 	const result = rows.reduce<
-		Record<DMChannel['id'], DMChannel & { participants: User[]; latestMessage?: App.DM }>
+		Record<
+			DMChannel['id'],
+			DMChannel & { participants: Record<User['id'], User>; latestMessage?: App.DM }
+		>
 	>((acc, row) => {
 		const channel = row.channel;
 		const participant = row.participant;
@@ -169,7 +174,7 @@ export const getDMChannels = async (
 		if (!acc[channel.id]) {
 			acc[channel.id] = {
 				...channel,
-				participants: [],
+				participants: {},
 				latestMessage: row.latestMessage && {
 					id: row.latestMessage.messageId,
 					sentAt: row.latestMessage.sentAt || new Date(),
@@ -180,12 +185,15 @@ export const getDMChannels = async (
 		}
 
 		if (participant) {
-			acc[channel.id].participants.push(participant);
+			acc[channel.id].participants[participant.id] = participant;
 		}
 		return acc;
 	}, {});
 
-	return Object.values(result);
+	return Object.values(result).map((acc) => ({
+		...acc,
+		participants: Object.values(acc.participants),
+	}));
 };
 
 export const beginDMProc = async (

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -49,43 +49,91 @@ export const createDMChannel = async (
 	return channelId;
 };
 
-export const joinToChannel = async (mainTx: Transaction, userId: string, channelId: string) => {
-	await mainTx.transaction(async (tx) => {
+export const joinToChannel = async (
+	mainTx: Transaction,
+	user: NonNullable<App.User>,
+	channelId: string,
+) => {
+	const dm = await mainTx.transaction(async (tx) => {
 		await tx.insert(table.dmParticipant).values({
 			channelId,
-			participantId: userId,
+			participantId: user.id,
 		});
+
+		const dm: App.DM = {
+			id: generateID(),
+			type: 'leave',
+			sentAt: new Date(),
+			sender: user,
+		};
 
 		await tx.insert(table.dmContent).values({
 			channelId,
-			messageId: generateID(),
-			sender: userId,
+			messageId: dm.id,
+			sender: user.id,
 			content: {
 				type: 'join',
 			},
 		});
+
+		return dm;
+	});
+
+	(
+		await db
+			.select({ uid: table.dmParticipant.participantId })
+			.from(table.dmParticipant)
+			.where(eq(table.dmParticipant.channelId, channelId))
+	).forEach(({ uid }) => {
+		telecom.notify(uid, { event: 'join', channelId, userId: user.id });
+		telecom.notify(uid, { event: 'dmSent', channelId, dms: [dm] });
 	});
 };
 
-export const leaveFromChannel = async (mainTx: Transaction, userId: string, channelId: string) => {
-	await mainTx.transaction(async (tx) => {
+export const leaveFromChannel = async (
+	mainTx: Transaction,
+	user: NonNullable<App.User>,
+	channelId: string,
+) => {
+	const dm = await mainTx.transaction(async (tx) => {
 		await tx
 			.delete(table.dmParticipant)
 			.where(
 				and(
 					eq(table.dmParticipant.channelId, channelId),
-					eq(table.dmParticipant.participantId, userId),
+					eq(table.dmParticipant.participantId, user.id),
 				),
 			);
 
+		const dm: App.DM = {
+			id: generateID(),
+			type: 'leave',
+			sentAt: new Date(),
+			sender: user,
+		};
+
 		await tx.insert(table.dmContent).values({
 			channelId,
-			messageId: generateID(),
-			sender: userId,
+			messageId: dm.id,
+			sender: user.id,
 			content: {
 				type: 'leave',
 			},
 		});
+
+		return dm;
+	});
+
+	telecom.notify(user.id, { event: 'leave', channelId, userId: user.id });
+
+	(
+		await db
+			.select({ uid: table.dmParticipant.participantId })
+			.from(table.dmParticipant)
+			.where(eq(table.dmParticipant.channelId, channelId))
+	).forEach(({ uid }) => {
+		telecom.notify(uid, { event: 'leave', channelId, userId: user.id });
+		telecom.notify(uid, { event: 'dmSent', channelId, dms: [dm] });
 	});
 };
 
@@ -197,16 +245,16 @@ export const getDMChannels = async (
 };
 
 export const beginDMProc = async (
-	fromUser: string,
-	toUser: string,
+	fromUser: NonNullable<App.User>,
+	toUser: NonNullable<App.User>,
 	type = DMChannelType.GENERAL,
 	relatedArticle?: string,
 ) => {
 	// 자기 자신과 DM할 수 없음
-	if (fromUser === toUser) throw new Error('Cannot chat with yourself', { cause: 400 });
+	if (fromUser.id === toUser.id) throw new Error('Cannot chat with yourself', { cause: 400 });
 
 	// 어느 한 쪽이 차단한 경우 DM할 수 없음
-	const relationship = await getRelationship(fromUser, toUser);
+	const relationship = await getRelationship(fromUser.id, toUser.id);
 
 	if (
 		relationship.fromUser === UserRelationship.BLOCKED ||
@@ -216,7 +264,7 @@ export const beginDMProc = async (
 
 	// 이미 채널이 있는 경우 해당 채널의 ID 반환
 	const result = (
-		await getDMChannels(fromUser, toUser, (_, ch) =>
+		await getDMChannels(fromUser.id, toUser.id, (_, ch) =>
 			and(eq(ch.type, type), relatedArticle ? eq(ch.relatedArticle, relatedArticle) : undefined),
 		)
 	).at(0);
@@ -229,6 +277,9 @@ export const beginDMProc = async (
 		// 해당 채널에 가입
 		await joinToChannel(tx, fromUser, channelId);
 		await joinToChannel(tx, toUser, channelId);
+
+		telecom.notify(fromUser.id, { event: 'join', channelId, userId: fromUser.id });
+		telecom.notify(toUser.id, { event: 'join', channelId, userId: toUser.id });
 
 		// 해당 채널 ID를 반환
 		return channelId;

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -297,17 +297,22 @@ export const getDMChannelInfo = async (channelId: string, sender: NonNullable<Ap
 			.where(eq(table.dmChannel.id, channelId))
 	).at(0);
 
-	const participants = await db
-		.select({
-			participant: table.user,
-		})
-		.from(table.dmParticipant)
-		.where(eq(table.dmParticipant.channelId, channelId))
-		.innerJoin(table.user, eq(table.user.id, table.dmParticipant.participantId));
+	const participants = (
+		await db
+			.select({
+				participant: table.user,
+			})
+			.from(table.dmParticipant)
+			.where(eq(table.dmParticipant.channelId, channelId))
+			.innerJoin(table.user, eq(table.user.id, table.dmParticipant.participantId))
+	).map((v) => v.participant);
+
+	if (participants.map((u) => u.id).indexOf(sender.id) === -1)
+		throw Error('You are not participated', { cause: 403 });
 
 	return {
 		...channelInfo,
-		participants: participants.map((v) => v.participant),
+		participants: participants,
 		isAbleToSend: await isAbleToSend(channelId, sender),
 	};
 };

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -2,10 +2,12 @@ import { DMChannelType, UserRelationship } from '@app';
 import { db, generateID, table } from '../db';
 import {
 	and,
+	count,
 	desc,
 	eq,
 	lte,
 	max,
+	sql,
 	SQL,
 	Subquery,
 	type ExtractTablesWithRelations,
@@ -16,6 +18,7 @@ import type { DMChannel, dmChannel, DMParticipant, User } from '../db/schema';
 import { message } from 'sveltekit-superforms';
 import { string } from 'zod';
 import type { PostgresJsQueryResultHKT } from 'drizzle-orm/postgres-js';
+import type { Emoji } from 'emoji-type';
 
 type Transaction =
 	| PgTransaction<
@@ -245,13 +248,35 @@ export const getDMChannelInfo = async (channelId: string) => {
 
 export type DMChannelInfo = Awaited<ReturnType<typeof getDMChannelInfo>>;
 
-export const get = async (channelId: string, before: Date) => {
+export const get = async (channelId: string, before: Date, me: NonNullable<App.User>) => {
 	const rmContent = alias(table.dmContent, 'rm_content');
 	const rmSender = alias(table.user, 'rm_sender');
 
-	const result = await db
+	const reactions = db
+		.select({
+			messageId: table.dmReactions.messageId,
+			emoji: table.dmReactions.emoji,
+			count: count(table.dmReactions.setter),
+		})
+		.from(table.dmReactions)
+		.where(eq(table.dmReactions.channelId, channelId))
+		.groupBy((t) => [t.messageId, t.emoji])
+		.as('reactions');
+
+	const metadata = db
 		.select({
 			id: table.dmContent.messageId,
+			reactions: sql<(typeof reactions)[]>`json_agg(reactions)`.as('reactions'),
+		})
+		.from(table.dmContent)
+		.where(and(eq(table.dmContent.channelId, channelId), lte(table.dmContent.sentAt, before)))
+		.leftJoin(reactions, eq(reactions.messageId, table.dmContent.messageId))
+		.groupBy((t) => t.id)
+		.as('metadata');
+
+	const result = await db
+		.select({
+			id: metadata.id,
 			sender: table.user,
 			content: table.dmContent.content,
 			sentAt: table.dmContent.sentAt,
@@ -261,9 +286,14 @@ export const get = async (channelId: string, before: Date) => {
 				sentAt: rmContent.sentAt,
 			},
 			relatedMessageSender: rmSender,
+			reactions: metadata.reactions,
+			myReaction: table.dmReactions.emoji,
 		})
-		.from(table.dmContent)
-		.where(and(eq(table.dmContent.channelId, channelId), lte(table.dmContent.sentAt, before)))
+		.from(metadata)
+		.innerJoin(
+			table.dmContent,
+			and(eq(table.dmContent.channelId, channelId), eq(table.dmContent.messageId, metadata.id)),
+		)
 		.innerJoin(table.user, eq(table.user.id, table.dmContent.sender))
 		.leftJoin(
 			rmContent,
@@ -272,13 +302,26 @@ export const get = async (channelId: string, before: Date) => {
 				eq(rmContent.messageId, table.dmContent.relatedMessage),
 			),
 		)
-		.leftJoin(rmSender, eq(rmSender.id, rmContent.sender));
+		.leftJoin(rmSender, eq(rmSender.id, rmContent.sender))
+		.leftJoin(
+			table.dmReactions,
+			and(
+				eq(table.dmReactions.channelId, channelId),
+				eq(table.dmReactions.messageId, metadata.id),
+				eq(table.dmReactions.setter, me.id),
+			),
+		);
 	// TODO: 일정 범위 이내의 값만 가져오도록 변경
 
 	return result.map<App.DM>((v) => ({
 		id: v.id,
 		sender: v.sender,
 		sentAt: v.sentAt,
+		reactions:
+			v.reactions[0] === null
+				? undefined
+				: Object.fromEntries(v.reactions.map((r) => [r.emoji, r.count])),
+		myReaction: v.myReaction || undefined,
 		...v.content,
 		relatedMessage:
 			(v.relatedMessage && {
@@ -361,4 +404,55 @@ export const send = async (
 			},
 		},
 	];
+};
+
+// ref: https://orm.drizzle.team/docs/perf-queries#placeholder
+const deleteReact = db
+	.delete(table.dmReactions)
+	.where(
+		and(
+			eq(table.dmReactions.channelId, sql.placeholder('channelId')),
+			eq(table.dmReactions.messageId, sql.placeholder('messageId')),
+			eq(table.dmReactions.setter, sql.placeholder('setter')),
+		),
+	);
+
+const upsertReact = db.insert(table.dmReactions).values({
+	channelId: sql.placeholder('channelId'),
+	messageId: sql.placeholder('messageId'),
+	setter: sql.placeholder('setter'),
+	emoji: sql.placeholder('emoji'),
+});
+
+export const react = async (
+	channelId: string,
+	messageId: string,
+	setter: NonNullable<App.User>,
+	emoji: Nullable<Emoji>,
+) => {
+	if (!emoji) {
+		await deleteReact.execute({
+			channelId,
+			messageId,
+			setter: setter.id,
+		});
+	} else {
+		await upsertReact
+			.onConflictDoUpdate({
+				target: [
+					table.dmReactions.channelId,
+					table.dmReactions.messageId,
+					table.dmReactions.setter,
+				],
+				set: {
+					emoji,
+				},
+			})
+			.execute({
+				channelId,
+				messageId,
+				emoji,
+				setter: setter.id,
+			});
+	}
 };

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -1,16 +1,38 @@
 import { DMChannelType, UserRelationship } from '@app';
 import { db, generateID, table } from '../db';
-import { and, desc, eq, lte, max, SQL, Subquery } from 'drizzle-orm';
+import {
+	and,
+	desc,
+	eq,
+	lte,
+	max,
+	SQL,
+	Subquery,
+	type ExtractTablesWithRelations,
+} from 'drizzle-orm';
 import { getRelationship } from './relationship';
-import { alias, intersect, union } from 'drizzle-orm/pg-core';
+import { alias, intersect, PgTransaction, union } from 'drizzle-orm/pg-core';
 import type { DMChannel, dmChannel, DMParticipant, User } from '../db/schema';
 import { message } from 'sveltekit-superforms';
 import { string } from 'zod';
+import type { PostgresJsQueryResultHKT } from 'drizzle-orm/postgres-js';
 
-export const createDMChannel = async (type = DMChannelType.GENERAL, relatedArticle?: string) => {
+type Transaction =
+	| PgTransaction<
+			PostgresJsQueryResultHKT,
+			Record<string, never>,
+			ExtractTablesWithRelations<Record<string, never>>
+	  >
+	| typeof db;
+
+export const createDMChannel = async (
+	mainTx: Transaction,
+	type = DMChannelType.GENERAL,
+	relatedArticle?: string,
+) => {
 	const channelId = generateID();
 
-	await db.insert(table.dmChannel).values({
+	await mainTx.insert(table.dmChannel).values({
 		id: channelId,
 		type,
 		relatedArticle,
@@ -19,39 +41,43 @@ export const createDMChannel = async (type = DMChannelType.GENERAL, relatedArtic
 	return channelId;
 };
 
-export const joinToChannel = async (userId: string, channelId: string) => {
-	await db.insert(table.dmParticipant).values({
-		channelId,
-		participantId: userId,
-	});
+export const joinToChannel = async (mainTx: Transaction, userId: string, channelId: string) => {
+	await mainTx.transaction(async (tx) => {
+		await tx.insert(table.dmParticipant).values({
+			channelId,
+			participantId: userId,
+		});
 
-	await db.insert(table.dmContent).values({
-		channelId,
-		messageId: generateID(),
-		sender: userId,
-		content: {
-			type: 'join',
-		},
+		await tx.insert(table.dmContent).values({
+			channelId,
+			messageId: generateID(),
+			sender: userId,
+			content: {
+				type: 'join',
+			},
+		});
 	});
 };
 
-export const leaveFromChannel = async (userId: string, channelId: string) => {
-	await db
-		.delete(table.dmParticipant)
-		.where(
-			and(
-				eq(table.dmParticipant.channelId, channelId),
-				eq(table.dmParticipant.participantId, userId),
-			),
-		);
+export const leaveFromChannel = async (mainTx: Transaction, userId: string, channelId: string) => {
+	await mainTx.transaction(async (tx) => {
+		await tx
+			.delete(table.dmParticipant)
+			.where(
+				and(
+					eq(table.dmParticipant.channelId, channelId),
+					eq(table.dmParticipant.participantId, userId),
+				),
+			);
 
-	await db.insert(table.dmContent).values({
-		channelId,
-		messageId: generateID(),
-		sender: userId,
-		content: {
-			type: 'leave',
-		},
+		await tx.insert(table.dmContent).values({
+			channelId,
+			messageId: generateID(),
+			sender: userId,
+			content: {
+				type: 'leave',
+			},
+		});
 	});
 };
 
@@ -182,15 +208,17 @@ export const beginDMProc = async (
 	).at(0);
 	if (result) return result.id;
 
-	// 채널 생성
-	const channelId = await createDMChannel(type, relatedArticle);
+	return await db.transaction(async (tx) => {
+		// 채널 생성
+		const channelId = await createDMChannel(tx, type, relatedArticle);
 
-	// 해당 채널에 가입
-	await joinToChannel(fromUser, channelId);
-	await joinToChannel(toUser, channelId);
+		// 해당 채널에 가입
+		await joinToChannel(tx, fromUser, channelId);
+		await joinToChannel(tx, toUser, channelId);
 
-	// 해당 채널 ID를 반환
-	return channelId;
+		// 해당 채널 ID를 반환
+		return channelId;
+	});
 };
 
 export const getDMChannelInfo = async (channelId: string) => {
@@ -272,49 +300,52 @@ export const send = async (
 	const messageId = generateID();
 	const sentAt = new Date();
 
-	await db.insert(table.dmContent).values({
-		channelId,
-		messageId,
-		sender: sender.id,
-		content,
-		sentAt,
-		relatedMessage,
-	});
+	const _relatedMessage = await db.transaction(async (tx) => {
+		await tx.insert(table.dmContent).values({
+			channelId,
+			messageId,
+			sender: sender.id,
+			content,
+			sentAt,
+			relatedMessage,
+		});
 
-	const attachments =
-		(content.type === 'general' && (content as App.GeneralDM).attachments) || undefined;
+		const attachments =
+			(content.type === 'general' && (content as App.GeneralDM).attachments) || undefined;
 
-	if (attachments)
-		await db.insert(table.filesPerDM).values(
-			attachments
-				.flatMap((v) => [...v.matchAll(/api\/file\/([A-Za-z0-9-\/]+)/g)])
-				.map((path) => ({
-					channelId,
-					messageId,
-					path: path[1],
-				})),
+		if (attachments)
+			await tx.insert(table.filesPerDM).values(
+				attachments
+					.flatMap((v) => [...v.matchAll(/api\/file\/([A-Za-z0-9-\/]+)/g)])
+					.map((path) => ({
+						channelId,
+						messageId,
+						path: path[1],
+					})),
+			);
+
+		return (
+			(relatedMessage &&
+				(
+					await tx
+						.select({
+							id: table.dmContent.messageId,
+							sender: table.user,
+							content: table.dmContent.content,
+							sentAt: table.dmContent.sentAt,
+						})
+						.from(table.dmContent)
+						.where(
+							and(
+								eq(table.dmContent.channelId, channelId),
+								eq(table.dmContent.messageId, relatedMessage),
+							),
+						)
+						.innerJoin(table.user, eq(table.user.id, table.dmContent.sender))
+				).at(0)) ||
+			undefined
 		);
-
-	const _relatedMessage =
-		(relatedMessage &&
-			(
-				await db
-					.select({
-						id: table.dmContent.messageId,
-						sender: table.user,
-						content: table.dmContent.content,
-						sentAt: table.dmContent.sentAt,
-					})
-					.from(table.dmContent)
-					.where(
-						and(
-							eq(table.dmContent.channelId, channelId),
-							eq(table.dmContent.messageId, relatedMessage),
-						),
-					)
-					.innerJoin(table.user, eq(table.user.id, table.dmContent.sender))
-			).at(0)) ||
-		undefined;
+	});
 
 	return [
 		{

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -274,6 +274,7 @@ export const get = async (channelId: string, before: Date, me: NonNullable<App.U
 		.leftJoin(reactions, eq(reactions.messageId, table.dmContent.messageId))
 		.groupBy((t) => t.id)
 		.as('metadata');
+	// TODO: 일정 범위 이내의 값만 가져오도록 변경
 
 	const result = await db
 		.select({
@@ -312,7 +313,18 @@ export const get = async (channelId: string, before: Date, me: NonNullable<App.U
 				eq(table.dmReactions.setter, me.id),
 			),
 		);
-	// TODO: 일정 범위 이내의 값만 가져오도록 변경
+
+	// 읽음 확인
+	await db
+		.insert(table.dmReceived)
+		.values(
+			result.map((message) => ({
+				channelId,
+				messageId: message.id,
+				receiver: me.id,
+			})),
+		)
+		.onConflictDoNothing();
 
 	return result.map<App.DM>((v) => ({
 		id: v.id,
@@ -367,6 +379,13 @@ export const send = async (
 						path: path[1],
 					})),
 			);
+
+		// 읽음 확인
+		await tx.insert(table.dmReceived).values({
+			channelId,
+			messageId,
+			receiver: sender.id,
+		});
 
 		return (
 			(relatedMessage &&

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -1,9 +1,10 @@
 import { DMChannelType, UserRelationship } from '@app';
 import { db, generateID, table } from '../db';
-import { and, eq, SQL, Subquery } from 'drizzle-orm';
+import { and, desc, eq, max, SQL, Subquery } from 'drizzle-orm';
 import { getRelationship } from './relationship';
 import { union } from 'drizzle-orm/pg-core';
 import type { DMChannel, dmChannel, DMParticipant, User } from '../db/schema';
+import { message } from 'sveltekit-superforms';
 
 export const createDMChannel = async (type = DMChannelType.GENERAL, relatedArticle?: string) => {
 	const channelId = generateID();
@@ -58,22 +59,33 @@ export const getDMChannels = async (
 	toUser?: string,
 	additionalWhere?: (part: Subquery, ch: typeof table.dmChannel) => SQL,
 ) => {
-	const fromUserQuery = db
-		.select()
-		.from(table.dmParticipant)
-		.where(eq(table.dmParticipant.participantId, fromUser));
+	const latestMessage = db
+		.select({
+			channelId: table.dmContent.channelId,
+			sentAt: max(table.dmContent.sentAt).as('sentAt'),
+		})
+		.from(table.dmContent)
+		.groupBy((t) => t.channelId)
+		.as('lm');
 
-	let subquery = (
-		toUser
-			? union(
-					fromUserQuery,
-					db
-						.select()
-						.from(table.dmParticipant)
-						.where(toUser ? eq(table.dmParticipant.participantId, toUser) : undefined),
-				)
-			: fromUserQuery
-	).as('sq');
+	const userQuery = (userId: string) =>
+		db
+			.select({
+				channelId: table.dmParticipant.channelId,
+				sentAt: latestMessage.sentAt,
+				content: table.dmContent.content,
+				messageId: table.dmContent.messageId,
+				sender: table.user,
+			})
+			.from(table.dmParticipant)
+			.where(eq(table.dmParticipant.participantId, userId))
+			.innerJoin(latestMessage, eq(latestMessage.channelId, table.dmParticipant.channelId))
+			.innerJoin(table.dmContent, eq(table.dmContent.sentAt, latestMessage.sentAt))
+			.innerJoin(table.user, eq(table.dmContent.sender, table.user.id));
+
+	const fromUserQuery = userQuery(fromUser);
+
+	let subquery = (toUser ? union(fromUserQuery, userQuery(toUser)) : fromUserQuery).as('sq');
 
 	const rows = await db
 		.select({
@@ -84,6 +96,12 @@ export const getDMChannels = async (
 				createdDate: table.dmChannel.createdDate,
 				closedDate: table.dmChannel.closedDate,
 			},
+			latestMessage: {
+				sentAt: subquery.sentAt,
+				content: subquery.content,
+				messageId: subquery.messageId,
+			},
+			latestMessageSender: subquery.sender,
 			participant: {
 				...table.user,
 				id: table.dmParticipant.participantId,
@@ -95,22 +113,30 @@ export const getDMChannels = async (
 		.innerJoin(table.dmParticipant, eq(table.dmParticipant.channelId, subquery.channelId))
 		.innerJoin(table.user, eq(table.user.id, table.dmParticipant.participantId));
 
-	const result = rows.reduce<Record<DMChannel['id'], DMChannel & { participants: User[] }>>(
-		(acc, row) => {
-			const channel = row.channel;
-			const participant = row.participant;
+	const result = rows.reduce<
+		Record<DMChannel['id'], DMChannel & { participants: User[]; latestMessage: App.DM }>
+	>((acc, row) => {
+		const channel = row.channel;
+		const participant = row.participant;
 
-			if (!acc[channel.id]) {
-				acc[channel.id] = { ...channel, participants: [] };
-			}
+		if (!acc[channel.id]) {
+			acc[channel.id] = {
+				...channel,
+				participants: [],
+				latestMessage: {
+					id: row.latestMessage.messageId,
+					sentAt: row.latestMessage.sentAt || new Date(),
+					sender: row.latestMessageSender,
+					...row.latestMessage.content,
+				},
+			};
+		}
 
-			if (participant) {
-				acc[channel.id].participants.push(participant);
-			}
-			return acc;
-		},
-		{},
-	);
+		if (participant) {
+			acc[channel.id].participants.push(participant);
+		}
+		return acc;
+	}, {});
 
 	return Object.values(result);
 };

--- a/src/lib/server/common/relationship.ts
+++ b/src/lib/server/common/relationship.ts
@@ -1,6 +1,7 @@
 import { UserRelationship } from '@app';
 import { db, table } from '../db';
 import { and, eq } from 'drizzle-orm';
+import { notify } from './telecom';
 
 export const blockUser = async (fromUser: string, toUser: string) => {
 	if (fromUser === toUser) throw new Error('Cannot block yourself', { cause: 400 });
@@ -17,6 +18,18 @@ export const blockUser = async (fromUser: string, toUser: string) => {
 			target: [table.userRelationship.from, table.userRelationship.to],
 			set: { relationship: UserRelationship.BLOCKED },
 		});
+
+	notify(toUser, {
+		event: 'relationshipChanged',
+		fromUser,
+		relationship: UserRelationship.BLOCKED,
+	});
+
+	notify(fromUser, {
+		event: 'relationshipChanged',
+		toUser,
+		relationship: UserRelationship.BLOCKED,
+	});
 };
 
 export const unblockUser = async (fromUser: string, toUser: string) => {
@@ -25,6 +38,14 @@ export const unblockUser = async (fromUser: string, toUser: string) => {
 	await db
 		.delete(table.userRelationship)
 		.where(and(eq(table.userRelationship.from, fromUser), eq(table.userRelationship.to, toUser)));
+
+	notify(toUser, { event: 'relationshipChanged', fromUser, relationship: UserRelationship.NONE });
+
+	notify(fromUser, {
+		event: 'relationshipChanged',
+		toUser,
+		relationship: UserRelationship.NONE,
+	});
 };
 
 export const getRelationship = async (fromUser: string, toUser: string) => {

--- a/src/lib/server/common/telecom.ts
+++ b/src/lib/server/common/telecom.ts
@@ -1,0 +1,26 @@
+import { db } from '../db';
+
+export type Callback = (message: any) => void;
+
+const listening: Record<string, () => Promise<void>> = {};
+
+export const listen = async (userId: string, key: string, cb: Callback) => {
+	const name = `${userId}_${key}`;
+
+	if (listening[name] !== undefined) listening[name]();
+
+	listening[name] = (
+		await db.$client.listen(userId, (notification: string) => {
+			const message = JSON.parse(notification);
+
+			cb(message);
+		})
+	).unlisten;
+
+	console.log(listening);
+
+	return listening[name];
+};
+
+export const notify = async (targetId: string, message: any) =>
+	await db.$client.notify(targetId, JSON.stringify(message));

--- a/src/lib/server/common/telecom.ts
+++ b/src/lib/server/common/telecom.ts
@@ -17,8 +17,6 @@ export const listen = async (userId: string, key: string, cb: Callback) => {
 		})
 	).unlisten;
 
-	console.log(listening);
-
 	return listening[name];
 };
 

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -181,8 +181,16 @@ export const dmContent = pgTable(
 			.references(() => user.id),
 		content: json('content').$type<Omit<App.DM, 'id' | 'sender' | 'sentAt'>>().notNull(),
 		sentAt: timestamp('sent_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+		relatedMessage: text('related_message'),
 	},
-	(table) => [primaryKey({ columns: [table.channelId, table.messageId] })],
+	(table) => [
+		primaryKey({ columns: [table.channelId, table.messageId] }),
+		foreignKey({
+			columns: [table.channelId, table.relatedMessage],
+			foreignColumns: [table.channelId, table.messageId],
+			name: 'dm_content_related_message_dm_content_message_id_fk',
+		}),
+	],
 );
 
 export const dmReceived = pgTable(

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -180,7 +180,7 @@ export const dmContent = pgTable(
 			.notNull()
 			.references(() => user.id),
 		content: json('content').$type<Omit<App.DM, 'id' | 'sender' | 'sentAt'>>().notNull(),
-		sentAt: timestamp('sent_at', { withTimezone: true, mode: 'date' }).defaultNow(),
+		sentAt: timestamp('sent_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
 	},
 	(table) => [primaryKey({ columns: [table.channelId, table.messageId] })],
 );

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -220,7 +220,7 @@ export const dmReactions = pgTable(
 		setter: text('setter')
 			.notNull()
 			.references(() => user.id),
-		emoji: text('setter').$type<Emoji>().notNull(),
+		emoji: text('emoji').$type<Emoji>().notNull(),
 	},
 	(table) => [
 		foreignKey({

--- a/src/lib/server/db/shorthands.ts
+++ b/src/lib/server/db/shorthands.ts
@@ -1,7 +1,19 @@
 import { AdultContents, ArticleType, UserRelationship, UserStatus } from '@app';
 import { db } from '.';
 import * as table from './schema';
-import { and, desc, eq, exists, ne, notExists, or, SQL, sql } from 'drizzle-orm';
+import {
+	and,
+	desc,
+	eq,
+	exists,
+	ne,
+	notExists,
+	or,
+	SQL,
+	sql,
+	type AnyColumn,
+	type GetColumnData,
+} from 'drizzle-orm';
 import { unionAll } from 'drizzle-orm/pg-core';
 import { isAdult } from '$lib/utils';
 
@@ -133,4 +145,11 @@ export const allArticles = (
 	}
 
 	return undefined;
+};
+
+export const aliasedColumn = <T extends AnyColumn>(
+	column: T,
+	alias: string,
+): SQL.Aliased<GetColumnData<T>> => {
+	return column.getSQL().mapWith(column.mapFromDriverValue).as(alias);
 };

--- a/src/routes/dm/+layout.server.ts
+++ b/src/routes/dm/+layout.server.ts
@@ -1,16 +1,13 @@
 import { error, redirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
-import { db, table } from '$lib/server/db';
-import { eq } from 'drizzle-orm';
 import * as dm from '$lib/server/common/dm';
 
-export const load = (async ({ params, locals }) => {
+export const load = (async ({ locals }) => {
 	if (!locals.user) throw redirect(300, '/');
 
 	try {
 		return {
 			channels: await dm.getDMChannels(locals.user.id),
-			id: params.id,
 		};
 	} catch (e) {
 		console.error(e);

--- a/src/routes/dm/+layout.svelte
+++ b/src/routes/dm/+layout.svelte
@@ -6,6 +6,6 @@
 	let { data, children }: { data: LayoutData; children: Snippet } = $props();
 </script>
 
-<Layout id={data.id} channels={data.channels}>
+<Layout channels={data.channels}>
 	{@render children()}
 </Layout>

--- a/src/routes/dm/[id]/+page.server.ts
+++ b/src/routes/dm/[id]/+page.server.ts
@@ -8,7 +8,7 @@ export const load = (async ({ locals, params }) => {
 	if (!locals.user) return {};
 
 	try {
-		const info = await dm.getDMChannelInfo(params.id);
+		const info = await dm.getDMChannelInfo(params.id, locals.user);
 		return { info };
 	} catch (e) {
 		console.error(e);

--- a/src/routes/dm/[id]/+page.server.ts
+++ b/src/routes/dm/[id]/+page.server.ts
@@ -33,14 +33,19 @@ export const actions: Actions = {
 	send: async ({ params, request, locals }) => {
 		if (!locals.user) return {};
 
-		const content = (await request.json()) as App.GeneralDM;
+		const { relatedMessage, ...content } = (await request.json()) as App.GeneralDM;
 		const channelId = params.id;
 
 		try {
-			const dms = await dm.send(channelId, locals.user, {
-				type: 'general',
-				...content,
-			});
+			const dms = await dm.send(
+				channelId,
+				locals.user,
+				{
+					type: 'general',
+					...content,
+				} as App.DM & App.GeneralDM,
+				relatedMessage?.id,
+			);
 
 			return { dms };
 		} catch (e) {

--- a/src/routes/dm/[id]/+page.server.ts
+++ b/src/routes/dm/[id]/+page.server.ts
@@ -1,5 +1,15 @@
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
+import * as dm from '$lib/server/common/dm';
 
-export const load = (async () => {
-	return {};
+export const load = (async ({ locals, params }) => {
+	if (!locals.user) return {};
+
+	try {
+		const info = await dm.getDMChannelInfo(params.id);
+		return { info };
+	} catch (e) {
+		console.error(e);
+		throw error(500, { message: 'An error has occurred' });
+	}
 }) satisfies PageServerLoad;

--- a/src/routes/dm/[id]/+page.server.ts
+++ b/src/routes/dm/[id]/+page.server.ts
@@ -1,4 +1,4 @@
-import { error, fail } from '@sveltejs/kit';
+import { error, fail, redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import * as dm from '$lib/server/common/dm';
 import type { Emoji } from 'emoji-type';
@@ -11,6 +11,10 @@ export const load = (async ({ locals, params }) => {
 		const info = await dm.getDMChannelInfo(params.id, locals.user);
 		return { info };
 	} catch (e) {
+		if (e instanceof Error && typeof e.cause === 'number') {
+			if (e.cause === 403) throw redirect(308, '/dm');
+		}
+
 		console.error(e);
 		throw error(500, { message: 'An error has occurred' });
 	}

--- a/src/routes/dm/[id]/+page.server.ts
+++ b/src/routes/dm/[id]/+page.server.ts
@@ -1,4 +1,4 @@
-import { error } from '@sveltejs/kit';
+import { error, fail } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import * as dm from '$lib/server/common/dm';
 import type { Emoji } from 'emoji-type';
@@ -28,7 +28,7 @@ export const actions: Actions = {
 			return { dms };
 		} catch (e) {
 			console.error(e);
-			throw error(500, { message: 'An error has occurred' });
+			return fail(500, { message: 'An error has occurred' });
 		}
 	},
 
@@ -51,8 +51,12 @@ export const actions: Actions = {
 
 			return { dms };
 		} catch (e) {
+			if (e instanceof Error && typeof e.cause === 'number') {
+				return fail(e.cause, { message: e.message });
+			}
+
 			console.error(e);
-			throw error(500, { message: 'An error has occurred' });
+			return fail(500, { message: 'An error has occurred' });
 		}
 	},
 
@@ -71,7 +75,7 @@ export const actions: Actions = {
 			return { message: 'React completed' };
 		} catch (e) {
 			console.error(e);
-			throw error(500, { message: 'An error has occurred' });
+			return fail(500, { message: 'An error has occurred' });
 		}
 	},
 
@@ -85,7 +89,7 @@ export const actions: Actions = {
 			return { message: 'Leave completed' };
 		} catch (e) {
 			console.error(e);
-			throw error(500, { message: 'An error has occurred' });
+			return fail(500, { message: 'An error has occurred' });
 		}
 	},
 };

--- a/src/routes/dm/[id]/+page.server.ts
+++ b/src/routes/dm/[id]/+page.server.ts
@@ -1,6 +1,7 @@
 import { error } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import * as dm from '$lib/server/common/dm';
+import type { Emoji } from 'emoji-type';
 
 export const load = (async ({ locals, params }) => {
 	if (!locals.user) return {};
@@ -22,7 +23,7 @@ export const actions: Actions = {
 		const channelId = params.id;
 
 		try {
-			const dms = await dm.get(channelId, before);
+			const dms = await dm.get(channelId, before, locals.user);
 			return { dms };
 		} catch (e) {
 			console.error(e);
@@ -48,6 +49,25 @@ export const actions: Actions = {
 			);
 
 			return { dms };
+		} catch (e) {
+			console.error(e);
+			throw error(500, { message: 'An error has occurred' });
+		}
+	},
+
+	react: async ({ params, request, locals }) => {
+		if (!locals.user) return {};
+
+		const body = await request.formData();
+
+		const emoji = body.get('emoji') as Emoji | null;
+		const messageId = body.get('messageId') as string;
+		const channelId = params.id;
+
+		try {
+			await dm.react(channelId, messageId, locals.user, emoji);
+
+			return { message: 'React completed' };
 		} catch (e) {
 			console.error(e);
 			throw error(500, { message: 'An error has occurred' });

--- a/src/routes/dm/[id]/+page.server.ts
+++ b/src/routes/dm/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-import type { PageServerLoad } from './$types';
+import type { Actions, PageServerLoad } from './$types';
 import * as dm from '$lib/server/common/dm';
 
 export const load = (async ({ locals, params }) => {
@@ -13,3 +13,18 @@ export const load = (async ({ locals, params }) => {
 		throw error(500, { message: 'An error has occurred' });
 	}
 }) satisfies PageServerLoad;
+
+export const actions: Actions = {
+	get: async ({ params, request }) => {
+		const before = new Date((await request.formData()).get('before') as string);
+		const channelId = params.id;
+
+		try {
+			const dms = await dm.get(channelId, before);
+			return { dms };
+		} catch (e) {
+			console.error(e);
+			throw error(500, { message: 'An error has occurred' });
+		}
+	},
+};

--- a/src/routes/dm/[id]/+page.server.ts
+++ b/src/routes/dm/[id]/+page.server.ts
@@ -20,7 +20,7 @@ export const actions: Actions = {
 	get: async ({ params, request, locals }) => {
 		if (!locals.user) return {};
 
-		const before = new Date((await request.formData()).get('before') as string);
+		const before = new Date(parseInt((await request.formData()).get('before') as string));
 		const channelId = params.id;
 
 		try {

--- a/src/routes/dm/[id]/+page.server.ts
+++ b/src/routes/dm/[id]/+page.server.ts
@@ -2,6 +2,7 @@ import { error } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import * as dm from '$lib/server/common/dm';
 import type { Emoji } from 'emoji-type';
+import { db } from '$lib/server/db';
 
 export const load = (async ({ locals, params }) => {
 	if (!locals.user) return {};
@@ -68,6 +69,20 @@ export const actions: Actions = {
 			await dm.react(channelId, messageId, locals.user, emoji);
 
 			return { message: 'React completed' };
+		} catch (e) {
+			console.error(e);
+			throw error(500, { message: 'An error has occurred' });
+		}
+	},
+
+	leave: async ({ params, locals }) => {
+		if (!locals.user) return {};
+
+		const channelId = params.id;
+
+		try {
+			await dm.leaveFromChannel(db, locals.user.id, channelId);
+			return { message: 'Leave completed' };
 		} catch (e) {
 			console.error(e);
 			throw error(500, { message: 'An error has occurred' });

--- a/src/routes/dm/[id]/+page.server.ts
+++ b/src/routes/dm/[id]/+page.server.ts
@@ -15,12 +15,33 @@ export const load = (async ({ locals, params }) => {
 }) satisfies PageServerLoad;
 
 export const actions: Actions = {
-	get: async ({ params, request }) => {
+	get: async ({ params, request, locals }) => {
+		if (!locals.user) return {};
+
 		const before = new Date((await request.formData()).get('before') as string);
 		const channelId = params.id;
 
 		try {
 			const dms = await dm.get(channelId, before);
+			return { dms };
+		} catch (e) {
+			console.error(e);
+			throw error(500, { message: 'An error has occurred' });
+		}
+	},
+
+	send: async ({ params, request, locals }) => {
+		if (!locals.user) return {};
+
+		const content = (await request.json()) as App.GeneralDM;
+		const channelId = params.id;
+
+		try {
+			const dms = await dm.send(channelId, locals.user, {
+				type: 'general',
+				...content,
+			});
+
 			return { dms };
 		} catch (e) {
 			console.error(e);

--- a/src/routes/dm/[id]/+page.server.ts
+++ b/src/routes/dm/[id]/+page.server.ts
@@ -85,7 +85,7 @@ export const actions: Actions = {
 		const channelId = params.id;
 
 		try {
-			await dm.leaveFromChannel(db, locals.user.id, channelId);
+			await dm.leaveFromChannel(db, locals.user, channelId);
 			return { message: 'Leave completed' };
 		} catch (e) {
 			console.error(e);

--- a/src/routes/dm/[id]/+page.svelte
+++ b/src/routes/dm/[id]/+page.svelte
@@ -5,4 +5,4 @@
 	let { data }: { data: PageData } = $props();
 </script>
 
-<Chat />
+<Chat info={data.info} />

--- a/src/routes/dm/sse/+server.ts
+++ b/src/routes/dm/sse/+server.ts
@@ -1,0 +1,27 @@
+import { listen } from '$lib/server/common/telecom';
+import { error, fail } from '@sveltejs/kit';
+import { produce } from 'sveltekit-sse';
+
+export const POST = ({ locals }) => {
+	let unlisten: () => Promise<void>;
+
+	return produce(
+		async ({ emit, lock }) => {
+			if (!locals.user) throw error(401);
+
+			unlisten = await listen(locals.user.id, 'dm-sse', (message) => {
+				const { error } = emit('message', JSON.stringify(message));
+
+				if (error) {
+					console.error(error);
+					lock.set(false);
+				}
+			});
+		},
+		{
+			stop: () => {
+				unlisten?.();
+			},
+		},
+	);
+};

--- a/src/routes/sse/+server.ts
+++ b/src/routes/sse/+server.ts
@@ -9,8 +9,8 @@ export const POST = ({ locals }) => {
 		async ({ emit, lock }) => {
 			if (!locals.user) throw error(401);
 
-			unlisten = await listen(locals.user.id, 'dm-sse', (message) => {
-				const { error } = emit('message', JSON.stringify(message));
+			unlisten = await listen(locals.user.id, 'sse', (message) => {
+				const { error } = emit(message.event || 'message', JSON.stringify(message));
 
 				if (error) {
 					console.error(error);

--- a/src/routes/user/[id]/+page.server.ts
+++ b/src/routes/user/[id]/+page.server.ts
@@ -340,7 +340,24 @@ export const actions: Actions = {
 		if (!locals.user) return fail(403, { message: 'Not logined' });
 
 		try {
-			const channelId = await beginDMProc(locals.user.id, params.id);
+			const user = (
+				await db
+					.select({
+						username: table.user.username,
+						profileImage: table.user.profileImage,
+						email: table.user.email,
+						preferences: table.user.preferences,
+						profile: table.user.profile,
+						id: table.user.id,
+						birthday: table.user.birthday,
+						authExpiresAt: table.user.authExpiresAt,
+						status: table.user.status,
+					})
+					.from(table.user)
+					.where(eq(table.user.id, params.id))
+			).at(0);
+
+			const channelId = await beginDMProc(locals.user, user!);
 
 			return { channelId };
 		} catch (e) {

--- a/src/stories/components/ArticleList.svelte
+++ b/src/stories/components/ArticleList.svelte
@@ -87,7 +87,10 @@
 					<Card.Description class="flex items-center justify-end space-x-2">
 						<span>by</span>
 						<Button variant="link" class="text-inherit" href="/user/{article?.author.id}">
-							<Avatar class="inline-block h-6 w-6 align-middle" user={article?.author} />
+							<Avatar
+								class="inline-block h-6 w-6 align-middle"
+								user={article?.author}
+								withoutLink />
 							{article?.author.username}
 						</Button>
 					</Card.Description>

--- a/src/stories/components/Avatar.svelte
+++ b/src/stories/components/Avatar.svelte
@@ -6,19 +6,22 @@
 	import User from 'lucide-svelte/icons/user';
 
 	interface Props extends HTMLSlotAttributes {
-		user: Pick<NonNullable<App.User>, 'profileImage' | 'username'> | null;
+		user: Pick<NonNullable<App.User>, 'id' | 'profileImage' | 'username'> | null;
 	}
 
 	const {
 		class: className = undefined,
 		user = {
+			id: '',
 			username: '',
 			profileImage: null,
 		},
 	}: Props = $props();
 </script>
 
-<Avatar.Root class={className}>
-	<Avatar.Image src={user?.profileImage} alt={user?.username} />
-	<Avatar.Fallback><User /></Avatar.Fallback>
-</Avatar.Root>
+<a href="/user/{user?.id}">
+	<Avatar.Root class={className}>
+		<Avatar.Image src={user?.profileImage} alt={user?.username} />
+		<Avatar.Fallback><User /></Avatar.Fallback>
+	</Avatar.Root>
+</a>

--- a/src/stories/components/Avatar.svelte
+++ b/src/stories/components/Avatar.svelte
@@ -7,6 +7,7 @@
 
 	interface Props extends HTMLSlotAttributes {
 		user: Pick<NonNullable<App.User>, 'id' | 'profileImage' | 'username'> | null;
+		withoutLink?: boolean;
 	}
 
 	const {
@@ -16,12 +17,21 @@
 			username: '',
 			profileImage: null,
 		},
+		withoutLink = false,
 	}: Props = $props();
 </script>
 
-<a href="/user/{user?.id}">
+{#snippet content()}
 	<Avatar.Root class={className}>
 		<Avatar.Image src={user?.profileImage} alt={user?.username} />
 		<Avatar.Fallback><User /></Avatar.Fallback>
 	</Avatar.Root>
-</a>
+{/snippet}
+
+{#if withoutLink}
+	{@render content()}
+{:else}
+	<a href="/user/{user?.id}">
+		{@render content()}
+	</a>
+{/if}

--- a/src/stories/components/Header.svelte
+++ b/src/stories/components/Header.svelte
@@ -79,7 +79,7 @@
 									variant="ghost"
 									class="size-9 rounded-full p-0"
 									aria-label="User Menu">
-									<UserAvatar class="size-9" {user} />
+									<UserAvatar class="size-9" {user} withoutLink />
 								</Button>
 							{/snippet}
 						</DropdownMenu.Trigger>

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -153,6 +153,29 @@
 		dmDraft.message += emoji || '';
 	};
 
+	const onReact = (messageId: string, emoji?: Emoji) => {
+		const target = dms.findIndex((dm) => dm.id === messageId);
+		const reactions = (dms[target] as App.GeneralDM).reactions || {};
+		let myReaction = (dms[target] as App.GeneralDM).myReaction;
+
+		if (myReaction) {
+			reactions[myReaction]! -= 1;
+			if (reactions[myReaction] === 0) delete reactions[myReaction];
+		}
+
+		if (emoji) {
+			if (!reactions[emoji]) reactions[emoji] = 1;
+			else reactions[emoji] += 1;
+		}
+		myReaction = emoji || undefined;
+
+		dms[target] = {
+			...dms[target],
+			reactions,
+			myReaction,
+		} as App.DM & App.GeneralDM;
+	};
+
 	const onReply = (message: App.DM) => {
 		dmDraft.relatedMessage = undefined;
 		tick().then(() => (dmDraft.relatedMessage = message));
@@ -194,6 +217,7 @@
 				onScrollToDM={scrollToDM}
 				{onOpenEmojiList}
 				{onReply}
+				{onReact}
 				tabindex={i + 1} />
 		{/each}
 	</section>

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -16,6 +16,8 @@
 	import UserAvatar from '$stories/components/Avatar.svelte';
 	import MediaListCarousel from '$stories/components/MediaListCarousel.svelte';
 	import * as Card from '$lib/components/ui/card';
+	import { onMount } from 'svelte';
+	import { deserialize } from '$app/forms';
 
 	interface Props extends ReturnType<typeof $props> {
 		info?: App.DMChannel;
@@ -26,186 +28,28 @@
 	let user = $state<App.User>(null);
 	userStore.subscribe((v) => (user = v));
 
-	const dms = $derived<App.DM[]>([
-		{
-			id: 'asdf',
-			type: 'join',
-			sender: user,
-			sentAt: new Date(1000000),
-		},
-		{
-			id: '1234',
-			type: 'general',
-			sender: user,
-			sentAt: new Date(1100000),
-			relatedPost: {
-				type: ArticleType.REQUEST,
-				article: {
-					thumbnail:
-						'https://media.planet.moe/cache/media_attachments/files/114/667/992/480/752/949/original/482dbc6092f63524.jpeg',
-					title: '없는 게시물',
-					author: user!,
-					category: ArticleCategory.TEXT,
-					tags: [],
-					id: 'asdf',
-				},
-			},
-		},
-		{
-			id: 'asdf',
-			type: 'general',
-			sender: user,
-			sentAt: new Date(1100000),
-			message: '이모티콘 테스트: 😂👨‍🦳✨🎂✈️💓',
-			reactions: {
-				'🤪': 1,
-				'😵': 1,
-			},
-		},
-		{
-			id: 'asdf',
-			type: 'general',
-			sender: user,
-			sentAt: new Date(1100000),
-			message: '😂👨‍🦳✨🎂✈️💓',
-		},
-		{
-			id: 'asdf',
-			type: 'general',
-			sender: user,
-			sentAt: new Date(1200000),
-			message: '장문의 기이이이이이이이다란 텍스트 메시지를 테스트해봅니다',
-		},
-		{
-			id: 'asdf',
-			type: 'general',
-			sender: user,
-			sentAt: new Date(1200000),
-			message: '장문의 기이이이이이이이다란\n텍스트 메시지를 테스트해봅니다',
-			reactions: {
-				'🤪': 1,
-				'😵': 1,
-			},
-			myReaction: '😵',
-		},
-		{
-			id: 'asdf',
-			type: 'general',
-			sender: user,
-			sentAt: new Date(1200000),
-			// message: '이미지 테스트',
-			attachments: [
-				'https://pbs.twimg.com/media/Gs_3JaFaMAA8kCN.jpg?name=orig',
-				'https://pbs.twimg.com/media/GtKU7MibMAMZzo5.jpg?name=orig',
-				'https://pbs.twimg.com/media/GtLOOpLbMAMp2Mw.jpg?name=orig',
-				'https://pbs.twimg.com/media/GtLQhrjbgAEz0HO.jpg?name=orig',
-				// 'https://pbs.twimg.com/media/GtIqoRvbMAAOYSm.jpg?name=orig',
-				// 'https://pbs.twimg.com/media/Gs_CdezaQAAL7iT.jpg?name=orig',
-				// 'https://pbs.twimg.com/media/GtA7WbyWIAAvEck.jpg?name=orig',
-				// 'https://pbs.twimg.com/media/GtFI0ZlagAAT-2g.jpg?name=orig',
-				// 'https://pbs.twimg.com/media/GtEveCeaIAA20dI.jpg?name=orig',
-				// 'https://pbs.twimg.com/media/Gs9_GlkboAAqmgS.jpg?name=orig',
-			],
-		},
-		{
-			id: '5678',
-			type: 'general',
-			sender: null,
-			sentAt: new Date(1200000),
-			message: '이미지 테스트',
-			attachments: [
-				'https://pbs.twimg.com/media/Gs_3JaFaMAA8kCN.jpg?name=orig',
-				'https://pbs.twimg.com/media/GtKU7MibMAMZzo5.jpg?name=orig',
-				'https://pbs.twimg.com/media/GtLOOpLbMAMp2Mw.jpg?name=orig',
-				'https://pbs.twimg.com/media/GtLQhrjbgAEz0HO.jpg?name=orig',
-				'https://pbs.twimg.com/media/GtIqoRvbMAAOYSm.jpg?name=orig',
-				'https://pbs.twimg.com/media/Gs_CdezaQAAL7iT.jpg?name=orig',
-				'https://pbs.twimg.com/media/GtA7WbyWIAAvEck.jpg?name=orig',
-				'https://pbs.twimg.com/media/GtFI0ZlagAAT-2g.jpg?name=orig',
-				'https://pbs.twimg.com/media/GtEveCeaIAA20dI.jpg?name=orig',
-				'https://pbs.twimg.com/media/Gs9_GlkboAAqmgS.jpg?name=orig',
-			],
-		},
-		{
-			id: 'asdf',
-			type: 'general',
-			sender: null,
-			sentAt: new Date(1200000),
-			message: '텍스트 메시지 테스트',
-		},
-		{
-			id: 'asdf',
-			type: 'general',
-			sender: null,
-			sentAt: new Date(1200000),
-			relatedMessage: {
-				id: '1234',
-				type: 'general',
-				sender: user,
-				sentAt: new Date(1100000),
-				message: '텍스트 메시지 테스트',
-			},
-			message: '답장형 메시지 테스트',
-		},
-		{
-			id: 'asdf',
-			type: 'general',
-			sender: null,
-			sentAt: new Date(1200000),
-			message: '장문의 기이이이이이이이다란 텍스트 메시지를 테스트해봅니다',
-			relatedPost: {
-				type: ArticleType.REQUEST,
-				article: {
-					thumbnail:
-						'https://media.planet.moe/cache/media_attachments/files/114/667/992/480/752/949/original/482dbc6092f63524.jpeg',
-					title: '없는 게시물',
-					author: user!,
-					category: ArticleCategory.TEXT,
-					tags: [],
-					id: 'asdf',
-				},
-			},
-		},
-		{
-			id: 'asdf',
-			type: 'general',
-			sender: null,
-			sentAt: new Date(1200000),
-			message: '😂👨‍🦳✨🎂✈️💓',
-		},
-		{
-			id: 'asdf',
-			type: 'general',
-			sender: user,
-			sentAt: new Date(1250000),
-			relatedMessage: {
-				id: '5678',
-				type: 'general',
-				sender: null,
-				sentAt: new Date(1200000),
-				// message: '이미지 테스트',
-				attachments: [
-					'https://pbs.twimg.com/media/Gs_3JaFaMAA8kCN.jpg?name=orig',
-					'https://pbs.twimg.com/media/GtKU7MibMAMZzo5.jpg?name=orig',
-					'https://pbs.twimg.com/media/GtLOOpLbMAMp2Mw.jpg?name=orig',
-					'https://pbs.twimg.com/media/GtLQhrjbgAEz0HO.jpg?name=orig',
-					'https://pbs.twimg.com/media/GtIqoRvbMAAOYSm.jpg?name=orig',
-					'https://pbs.twimg.com/media/Gs_CdezaQAAL7iT.jpg?name=orig',
-					'https://pbs.twimg.com/media/GtA7WbyWIAAvEck.jpg?name=orig',
-					'https://pbs.twimg.com/media/GtFI0ZlagAAT-2g.jpg?name=orig',
-					'https://pbs.twimg.com/media/GtEveCeaIAA20dI.jpg?name=orig',
-					'https://pbs.twimg.com/media/Gs9_GlkboAAqmgS.jpg?name=orig',
-				],
-			},
-			message: '답장형 메시지 테스트',
-		},
-		{
-			id: 'asdf',
-			type: 'leave',
-			sender: user,
-			sentAt: new Date(1300000),
-		},
-	]);
+	let dms = $state<App.DM[]>([]);
+
+	const getDM = async (before = new Date()) => {
+		const body = new FormData();
+		body.append('before', before.toString());
+
+		const result = await fetch('?/get', { method: 'post', body })
+			.then((r) => r.text())
+			.then((r) => deserialize(r));
+
+		if (result.type === 'success') {
+			const new_dms = result.data?.dms as App.DM[] | undefined;
+
+			if (new_dms && new_dms.length > 0) dms = [...new_dms, ...dms];
+			// } else {
+			// 	openErrorOnBeginDM = true;
+		}
+	};
+
+	onMount(() => {
+		getDM();
+	});
 
 	let container = $state<HTMLElement>();
 
@@ -232,6 +76,8 @@
 
 		container.scroll({ top: element.offsetTop });
 	};
+
+	// TODO: 스크롤 위치가 일정 범위 내일 때 마지막 DM 날짜 이전의 DM 불러오기. 만약에 없는 경우 이벤트 연결 끊기
 
 	let openEmojiList = $state(false);
 	let emojiListProps = $state({

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -140,6 +140,10 @@
 		}
 	};
 
+	const onKeyUp = (event: KeyboardEvent) => {
+		if (event.key === 'Enter') return onSend();
+	};
+
 	const onEmoji: EmojiEventHandler = (emoji) => {
 		dmDraft.message += emoji || '';
 	};
@@ -230,7 +234,11 @@
 			<!-- 파일 첨부 -->
 			<Paperclip />
 		</Button>
-		<Input name="chat" placeholder="메시지를 입력하세요..." bind:value={dmDraft.message} />
+		<Input
+			name="chat"
+			placeholder="메시지를 입력하세요..."
+			bind:value={dmDraft.message}
+			onkeyup={onKeyUp} />
 		<Button size="icon" variant="secondary" onclick={(event) => onOpenEmojiList(event, onEmoji)}>
 			<!-- 이모티콘 추가 -->
 			<SmilePlus />

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -4,12 +4,12 @@
 	import Input from '$lib/components/ui/input/input.svelte';
 	import Header from '$stories/components/Header.svelte';
 	import Section from '$stories/components/Section.svelte';
-	import { Paperclip, SendHorizontal, SmilePlus, X } from 'lucide-svelte';
+	import { EllipsisVertical, Paperclip, SendHorizontal, SmilePlus, X } from 'lucide-svelte';
 	import Message, { Direction } from './Message.svelte';
 	import { userStore } from '$lib/context';
 	import { ArticleCategory, ArticleType } from '@app';
 	import EmojiList, { type EmojiEventHandler } from '$stories/components/EmojiList.svelte';
-	import { onNavigate } from '$app/navigation';
+	import { goto, onNavigate } from '$app/navigation';
 	import type { Emoji } from 'emoji-type';
 	import { cn, formatDatetimeString, sanitizeHTML, twemoji, uploadImage } from '$lib/utils';
 	import Muted from '$lib/components/typo/muted.svelte';
@@ -20,6 +20,8 @@
 	import { deserialize } from '$app/forms';
 	import Dropzone from 'svelte-file-dropzone';
 	import { imageFormat } from '$lib/config';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import AlertDialog from '$stories/components/AlertDialog.svelte';
 
 	interface Props extends ReturnType<typeof $props> {
 		info?: App.DMChannel;
@@ -198,12 +200,42 @@
 	};
 
 	const title = `${info?.participants.filter((v) => v.id !== user!.id).map((v) => v.username)} 님과의 대화`;
+
+	let openBeforeLeaveAlert = $state(false);
+	const onLeave = async () => {
+		const result = await fetch('?/leave', { method: 'post', body: new FormData() })
+			.then((r) => r.text())
+			.then((r) => deserialize(r));
+
+		if (result.type === 'success') {
+			goto('/dm');
+		}
+	};
 </script>
 
 <Header {title} />
 
 <Section class="flex size-full flex-col">
-	<H2 class="flex-none">{title}</H2>
+	<H2 class="flex flex-none justify-between">
+		<span>{title}</span>
+		<DropdownMenu.Root>
+			<DropdownMenu.Trigger class="m-0 p-0">
+				{#snippet child({ props })}
+					<Button {...props} variant="ghost" size="icon"><EllipsisVertical /></Button>
+				{/snippet}
+			</DropdownMenu.Trigger>
+			<DropdownMenu.Content class="w-56" align="end">
+				<DropdownMenu.Group>
+					<DropdownMenu.Item onclick={() => (openBeforeLeaveAlert = true)}>
+						나가기
+					</DropdownMenu.Item>
+					<!-- TODO 구현 완료 시 재활성화
+					<DropdownMenu.Item onclick={() => {}}>신고하고 나가기</DropdownMenu.Item>
+					-->
+				</DropdownMenu.Group>
+			</DropdownMenu.Content>
+		</DropdownMenu.Root>
+	</H2>
 	<section
 		bind:this={container}
 		class="bg-background relative mt-4 size-full space-y-2 overflow-y-auto border p-2">
@@ -313,3 +345,10 @@
 </Section>
 
 <EmojiList bind:open={openEmojiList} {...emojiListProps} />
+
+<AlertDialog
+	title="정말로 나가시겠습니까?"
+	description="나간 이후에도 새로운 대화방에서 대화를 진행할 수 있습니다. 이를 원하지 않는 경우 상대방을 차단하시기 바랍니다."
+	cancel={true}
+	onAction={onLeave}
+	bind:open={openBeforeLeaveAlert} />

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -374,9 +374,10 @@
 		</Dropzone>
 		<Input
 			name="chat"
-			placeholder="메시지를 입력하세요..."
+			placeholder={info?.isAbleToSend ? '메시지를 입력하세요...' : '대화할 수 없는 대화방입니다.'}
 			bind:value={dmDraft.message}
-			onkeyup={onKeyUp} />
+			onkeyup={onKeyUp}
+			disabled={!info?.isAbleToSend} />
 		<Button size="icon" variant="secondary" onclick={(event) => onOpenEmojiList(event, onEmoji)}>
 			<!-- 이모티콘 추가 -->
 			<SmilePlus />

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import H2 from '$lib/components/typo/h2.svelte';
-	import Button from '$lib/components/ui/button/button.svelte';
+	import Button, { buttonVariants } from '$lib/components/ui/button/button.svelte';
 	import Input from '$lib/components/ui/input/input.svelte';
 	import Header from '$stories/components/Header.svelte';
 	import Section from '$stories/components/Section.svelte';
@@ -11,13 +11,15 @@
 	import EmojiList, { type EmojiEventHandler } from '$stories/components/EmojiList.svelte';
 	import { onNavigate } from '$app/navigation';
 	import type { Emoji } from 'emoji-type';
-	import { formatDatetimeString, sanitizeHTML, twemoji } from '$lib/utils';
+	import { cn, formatDatetimeString, sanitizeHTML, twemoji, uploadImage } from '$lib/utils';
 	import Muted from '$lib/components/typo/muted.svelte';
 	import UserAvatar from '$stories/components/Avatar.svelte';
 	import MediaListCarousel from '$stories/components/MediaListCarousel.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { onMount, tick } from 'svelte';
 	import { deserialize } from '$app/forms';
+	import Dropzone from 'svelte-file-dropzone';
+	import { imageFormat } from '$lib/config';
 
 	interface Props extends ReturnType<typeof $props> {
 		info?: App.DMChannel;
@@ -154,6 +156,22 @@
 		tick().then(() => (dmDraft.relatedMessage = message));
 	};
 
+	const onDropMedia = async ({ detail }: any) => {
+		const { acceptedFiles } = detail;
+
+		let imageFile = acceptedFiles[0];
+
+		if (!imageFile) return;
+
+		try {
+			const path = await uploadImage(imageFile);
+
+			dmDraft.attachments = [...(dmDraft.attachments || []), path];
+		} catch (err) {
+			console.error(err);
+		}
+	};
+
 	const title = `${info?.participants.filter((v) => v.id !== user!.id).map((v) => v.username)} 님과의 대화`;
 </script>
 
@@ -237,10 +255,21 @@
 		</section>
 	{/if}
 	<section class="bg-background flex w-full items-center space-x-2 border border-t-0 p-2">
-		<Button size="icon" variant="secondary">
+		<Dropzone
+			accept={imageFormat}
+			on:drop={onDropMedia}
+			multiple={false}
+			class={cn(
+				buttonVariants({
+					variant: 'secondary',
+					size: 'icon',
+				}),
+			)}>
+			<!-- <Button size="icon" variant="secondary"> -->
 			<!-- 파일 첨부 -->
 			<Paperclip />
-		</Button>
+			<!-- </Button> -->
+		</Dropzone>
 		<Input
 			name="chat"
 			placeholder="메시지를 입력하세요..."

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -22,6 +22,7 @@
 	import { imageFormat } from '$lib/config';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import AlertDialog from '$stories/components/AlertDialog.svelte';
+	import { toast } from 'svelte-sonner';
 
 	interface Props extends ReturnType<typeof $props> {
 		info?: App.DMChannel;
@@ -168,8 +169,15 @@
 
 			dmDraft = defaultDraft;
 			tick().then(() => scrollToBottom());
-			// } else {
-			// 	openErrorOnBeginDM = true;
+		} else {
+			console.log(result);
+
+			if (result.status === 406)
+				toast.error(
+					'이 대화방에서 메시지를 수신할 대상이 없습니다. 대화가 종료되었거나 상대방이 차단했을 수 있습니다.',
+				);
+			else
+				toast.error('메시지를 보내는 도중 오류가 발생하였습니다. 고객센터에 문의하시기 바랍니다.');
 		}
 	};
 

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -23,6 +23,8 @@
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import AlertDialog from '$stories/components/AlertDialog.svelte';
 	import { toast } from 'svelte-sonner';
+	import { source } from 'sveltekit-sse';
+	import { page } from '$app/state';
 
 	interface Props extends ReturnType<typeof $props> {
 		info?: App.DMChannel;
@@ -163,12 +165,12 @@
 			.then((r) => deserialize(r));
 
 		if (result.type === 'success') {
-			const new_dms = result.data?.dms as App.DM[] | undefined;
+			// const new_dms = result.data?.dms as App.DM[] | undefined;
 
-			if (new_dms && new_dms.length > 0) dms = [...dms, ...new_dms];
+			// if (new_dms && new_dms.length > 0) dms = [...dms, ...new_dms];
 
 			dmDraft = defaultDraft;
-			tick().then(() => scrollToBottom());
+			scrollToBottom();
 		} else {
 			console.log(result);
 
@@ -180,6 +182,28 @@
 				toast.error('메시지를 보내는 도중 오류가 발생하였습니다. 고객센터에 문의하시기 바랍니다.');
 		}
 	};
+
+	source('/dm/sse')
+		.select('message')
+		.subscribe((message) => {
+			if (!message) return;
+			const parsed = JSON.parse(message);
+
+			if (parsed.channelId !== page.params.id) return;
+
+			const new_dms = parsed.dms.map((dm: App.DM) => ({ ...dm, sentAt: new Date(dm.sentAt) })) as
+				| App.DM[]
+				| undefined;
+
+			console.log(new_dms);
+
+			if (new_dms && new_dms.length > 0) dms = [...dms, ...new_dms];
+
+			if (container) {
+				if (container.scrollTop >= container.scrollHeight - container.clientHeight - 100)
+					tick().then(() => scrollToBottom());
+			}
+		});
 
 	const onKeyUp = (event: KeyboardEvent) => {
 		if (event.key === 'Enter') return onSend();

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -16,7 +16,7 @@
 	import UserAvatar from '$stories/components/Avatar.svelte';
 	import MediaListCarousel from '$stories/components/MediaListCarousel.svelte';
 	import * as Card from '$lib/components/ui/card';
-	import { onMount } from 'svelte';
+	import { onMount, tick } from 'svelte';
 	import { deserialize } from '$app/forms';
 
 	interface Props extends ReturnType<typeof $props> {
@@ -48,7 +48,7 @@
 	};
 
 	onMount(() => {
-		getDM();
+		getDM().then(scrollToBottom);
 	});
 
 	let container = $state<HTMLElement>();
@@ -63,7 +63,7 @@
 		container.scroll({ top: element.offsetTop });
 	};
 
-	onNavigate(scrollToBottom);
+	onNavigate(() => getDM().then(scrollToBottom));
 	$effect(scrollToBottom);
 
 	const scrollToDM = (id: string) => {
@@ -135,6 +135,7 @@
 			if (new_dms && new_dms.length > 0) dms = [...dms, ...new_dms];
 
 			dmDraft = defaultDraft;
+			tick().then(() => scrollToBottom());
 			// } else {
 			// 	openErrorOnBeginDM = true;
 		}
@@ -146,6 +147,11 @@
 
 	const onEmoji: EmojiEventHandler = (emoji) => {
 		dmDraft.message += emoji || '';
+	};
+
+	const onReply = (message: App.DM) => {
+		dmDraft.relatedMessage = undefined;
+		tick().then(() => (dmDraft.relatedMessage = message));
 	};
 
 	const title = `${info?.participants.filter((v) => v.id !== user!.id).map((v) => v.username)} 님과의 대화`;
@@ -167,6 +173,7 @@
 				id="dm-{dm.id}"
 				onScrollToDM={scrollToDM}
 				{onOpenEmojiList}
+				{onReply}
 				tabindex={i + 1} />
 		{/each}
 	</section>

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -7,9 +7,9 @@
 	import { EllipsisVertical, Paperclip, SendHorizontal, SmilePlus, X } from 'lucide-svelte';
 	import Message, { Direction } from './Message.svelte';
 	import { userStore } from '$lib/context';
-	import { ArticleCategory, ArticleType } from '@app';
+	import { ArticleCategory, ArticleType, UserRelationship } from '@app';
 	import EmojiList, { type EmojiEventHandler } from '$stories/components/EmojiList.svelte';
-	import { goto, onNavigate } from '$app/navigation';
+	import { goto, invalidate, invalidateAll, onNavigate } from '$app/navigation';
 	import type { Emoji } from 'emoji-type';
 	import { cn, formatDatetimeString, sanitizeHTML, twemoji, uploadImage } from '$lib/utils';
 	import Muted from '$lib/components/typo/muted.svelte';
@@ -183,28 +183,6 @@
 		}
 	};
 
-	source('/sse')
-		.select('dmSent')
-		.subscribe((message) => {
-			if (!message) return;
-			const parsed = JSON.parse(message);
-
-			if (parsed.channelId !== page.params.id) return;
-
-			const new_dms = parsed.dms.map((dm: App.DM) => ({ ...dm, sentAt: new Date(dm.sentAt) })) as
-				| App.DM[]
-				| undefined;
-
-			console.log(new_dms);
-
-			if (new_dms && new_dms.length > 0) dms = [...dms, ...new_dms];
-
-			if (container) {
-				if (container.scrollTop >= container.scrollHeight - container.clientHeight - 100)
-					tick().then(() => scrollToBottom());
-			}
-		});
-
 	const onKeyUp = (event: KeyboardEvent) => {
 		if (event.key === 'Enter') return onSend();
 	};
@@ -278,6 +256,41 @@
 
 	const sameSender = (dest: App.DM, dm: App.DM) =>
 		!['join', 'leave'].includes(dest?.type || '') && dest?.sender?.id === dm.sender?.id;
+
+	source('/sse')
+		.select('dmSent')
+		.subscribe((message) => {
+			if (!message) return;
+			const parsed = JSON.parse(message);
+
+			if (parsed.channelId !== page.params.id) return;
+
+			const new_dms = parsed.dms.map((dm: App.DM) => ({ ...dm, sentAt: new Date(dm.sentAt) })) as
+				| App.DM[]
+				| undefined;
+
+			console.log(new_dms);
+
+			if (new_dms && new_dms.length > 0) dms = [...dms, ...new_dms];
+
+			if (container) {
+				if (container.scrollTop >= container.scrollHeight - container.clientHeight - 100)
+					tick().then(() => scrollToBottom());
+			}
+		});
+
+	source('/sse')
+		.select('relationshipChanged')
+		.subscribe(async (message) => {
+			if (!message) return;
+			const parsed = JSON.parse(message);
+
+			console.log(parsed);
+
+			if (!participants.find((p) => p.id === parsed.fromUser || p.id === parsed.toUser)) return;
+
+			invalidateAll();
+		});
 </script>
 
 <Header {title} />

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -183,8 +183,8 @@
 		}
 	};
 
-	source('/dm/sse')
-		.select('message')
+	source('/sse')
+		.select('dmSent')
 		.subscribe((message) => {
 			if (!message) return;
 			const parsed = JSON.parse(message);

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -199,7 +199,12 @@
 		}
 	};
 
-	const title = `${info?.participants.filter((v) => v.id !== user!.id).map((v) => v.username)} 님과의 대화`;
+	const participants = info?.participants.filter((v) => v.id !== user!.id) || [];
+
+	const title =
+		participants.length > 0
+			? `${info?.participants.filter((v) => v.id !== user!.id).map((v) => v.username)} 님과의 대화`
+			: '종료된 대화';
 
 	let openBeforeLeaveAlert = $state(false);
 	const onLeave = async () => {

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -32,11 +32,12 @@
 	let user = $state<App.User>(null);
 	userStore.subscribe((v) => (user = v));
 
+	let enableScrollEvent = $state(false);
 	let dms = $state<App.DM[]>([]);
 
 	const getDM = async (before = new Date()) => {
 		const body = new FormData();
-		body.append('before', before.toString());
+		body.append('before', before.getTime().toString());
 
 		const result = await fetch('?/get', { method: 'post', body })
 			.then((r) => r.text())
@@ -45,7 +46,19 @@
 		if (result.type === 'success') {
 			const new_dms = result.data?.dms as App.DM[] | undefined;
 
-			if (new_dms && new_dms.length > 0) dms = [...new_dms, ...dms];
+			if (new_dms && new_dms.length > 0) {
+				dms = Object.values(
+					[...new_dms, ...dms].reduce<Record<string, App.DM>>(
+						(acc, dm) => (acc[dm.id] = dm) && acc,
+						{},
+					),
+				);
+				enableScrollEvent = true;
+				await tick();
+				scrollToDM(new_dms[new_dms.length - 1].id);
+			} else {
+				enableScrollEvent = false;
+			}
 			// } else {
 			// 	openErrorOnBeginDM = true;
 		}
@@ -67,8 +80,21 @@
 		container.scroll({ top: element.offsetTop });
 	};
 
+	const onScrollContainer = () => {
+		if (!container) return;
+
+		if (enableScrollEvent && container.scrollTop < 100) {
+			enableScrollEvent = false;
+			getDM(dms[0].sentAt);
+		}
+	};
+
 	onNavigate((nav) => {
-		nav.to?.route.id === '/dm/[id]' && getDM().then(scrollToBottom);
+		if (nav.to?.route.id === '/dm/[id]') {
+			dms = [];
+			enableScrollEvent = false;
+			getDM().then(scrollToBottom);
+		}
 	});
 	$effect(scrollToBottom);
 
@@ -216,6 +242,9 @@
 			goto('/dm');
 		}
 	};
+
+	const sameSender = (dest: App.DM, dm: App.DM) =>
+		!['join', 'leave'].includes(dest?.type || '') && dest?.sender?.id === dm.sender?.id;
 </script>
 
 <Header {title} />
@@ -243,13 +272,15 @@
 	</H2>
 	<section
 		bind:this={container}
+		onscroll={onScrollContainer}
 		class="bg-background relative mt-4 size-full space-y-2 overflow-y-auto border p-2">
 		{#each dms as dm, i}
 			<Message
 				dir={dm.sender!.id === user!.id ? Direction.SEND : Direction.RECEIVE}
 				{dm}
-				prev={dms[i - 1]}
-				next={dms[i + 1]}
+				sameSenderAsPrev={sameSender(dms[i - 1], dm)}
+				sameSenderAsNext={sameSender(dms[i + 1], dm)}
+				sentAtOfNext={dms[i + 1]?.sentAt}
 				id="dm-{dm.id}"
 				onScrollToDM={scrollToDM}
 				{onOpenEmojiList}

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -292,7 +292,7 @@
 
 	source('/sse')
 		.select('join')
-		.subscribe(async (message) => {
+		.subscribe((message) => {
 			if (!message) return;
 			const parsed = JSON.parse(message);
 
@@ -303,13 +303,14 @@
 
 	source('/sse')
 		.select('leave')
-		.subscribe(async (message) => {
+		.subscribe((message) => {
 			if (!message) return;
 			const parsed = JSON.parse(message);
 
 			if (parsed.channelId !== page.params.id) return;
 
-			invalidateAll();
+			if (parsed.userId === user!.id) goto('/dm', { invalidateAll: true });
+			else invalidateAll();
 		});
 </script>
 

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -285,9 +285,29 @@
 			if (!message) return;
 			const parsed = JSON.parse(message);
 
-			console.log(parsed);
-
 			if (!participants.find((p) => p.id === parsed.fromUser || p.id === parsed.toUser)) return;
+
+			invalidateAll();
+		});
+
+	source('/sse')
+		.select('join')
+		.subscribe(async (message) => {
+			if (!message) return;
+			const parsed = JSON.parse(message);
+
+			if (parsed.channelId !== page.params.id) return;
+
+			invalidateAll();
+		});
+
+	source('/sse')
+		.select('leave')
+		.subscribe(async (message) => {
+			if (!message) return;
+			const parsed = JSON.parse(message);
+
+			if (parsed.channelId !== page.params.id) return;
 
 			invalidateAll();
 		});

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -17,9 +17,11 @@
 	import MediaListCarousel from '$stories/components/MediaListCarousel.svelte';
 	import * as Card from '$lib/components/ui/card';
 
-	interface Props extends ReturnType<typeof $props> {}
+	interface Props extends ReturnType<typeof $props> {
+		info?: App.DMChannel;
+	}
 
-	const {}: Props = $props();
+	const { info }: Props = $props();
 
 	let user = $state<App.User>(null);
 	userStore.subscribe((v) => (user = v));
@@ -272,12 +274,14 @@
 	const onEmoji: EmojiEventHandler = (emoji) => {
 		dmDraft.message += emoji || '';
 	};
+
+	const title = `${info?.participants.filter((v) => v.id !== user!.id).map((v) => v.username)} 님과의 대화`;
 </script>
 
-<Header title="뫄뫄 님과의 대화" />
+<Header {title} />
 
 <Section class="flex size-full flex-col">
-	<H2 class="flex-none">뫄뫄 님과의 대화</H2>
+	<H2 class="flex-none">{title}</H2>
 	<section
 		bind:this={container}
 		class="bg-background relative mt-4 size-full space-y-2 overflow-y-auto border p-2">

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -250,7 +250,7 @@
 			.then((r) => deserialize(r));
 
 		if (result.type === 'success') {
-			goto('/dm');
+			await invalidateAll();
 		}
 	};
 

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -65,7 +65,9 @@
 		container.scroll({ top: element.offsetTop });
 	};
 
-	onNavigate(() => getDM().then(scrollToBottom));
+	onNavigate((nav) => {
+		nav.to?.route.id === '/dm/[id]' && getDM().then(scrollToBottom);
+	});
 	$effect(scrollToBottom);
 
 	const scrollToDM = (id: string) => {

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -233,12 +233,13 @@
 		}
 	};
 
-	const participants = info?.participants.filter((v) => v.id !== user!.id) || [];
+	const participants = $derived(info?.participants.filter((v) => v.id !== user!.id) || []);
 
-	const title =
+	const title = $derived(
 		participants.length > 0
 			? `${info?.participants.filter((v) => v.id !== user!.id).map((v) => v.username)} 님과의 대화`
-			: '종료된 대화';
+			: '종료된 대화',
+	);
 
 	let openBeforeLeaveAlert = $state(false);
 	const onLeave = async () => {

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -113,9 +113,32 @@
 		openEmojiList = true;
 	};
 
-	let dmDraft = $state<App.GeneralDM>({
+	const defaultDraft: App.GeneralDM = {
 		message: '',
-	});
+	};
+
+	let dmDraft = $state(defaultDraft);
+
+	const onSend = async () => {
+		if (JSON.stringify(dmDraft) === JSON.stringify(defaultDraft)) return;
+
+		const result = await fetch('?/send', {
+			method: 'post',
+			body: JSON.stringify(dmDraft),
+		})
+			.then((r) => r.text())
+			.then((r) => deserialize(r));
+
+		if (result.type === 'success') {
+			const new_dms = result.data?.dms as App.DM[] | undefined;
+
+			if (new_dms && new_dms.length > 0) dms = [...dms, ...new_dms];
+
+			dmDraft = defaultDraft;
+			// } else {
+			// 	openErrorOnBeginDM = true;
+		}
+	};
 
 	const onEmoji: EmojiEventHandler = (emoji) => {
 		dmDraft.message += emoji || '';
@@ -133,7 +156,7 @@
 		class="bg-background relative mt-4 size-full space-y-2 overflow-y-auto border p-2">
 		{#each dms as dm, i}
 			<Message
-				dir={dm.sender ? Direction.RECEIVE : Direction.SEND}
+				dir={dm.sender!.id === user!.id ? Direction.SEND : Direction.RECEIVE}
 				{dm}
 				prev={dms[i - 1]}
 				next={dms[i + 1]}
@@ -212,7 +235,7 @@
 			<!-- 이모티콘 추가 -->
 			<SmilePlus />
 		</Button>
-		<Button size="icon">
+		<Button size="icon" onclick={onSend}>
 			<!-- 전송 -->
 			<SendHorizontal />
 		</Button>

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -7,7 +7,7 @@
 
 	interface Props extends ReturnType<typeof $props> {
 		id?: string;
-		channels: (DMChannel & { participants?: App.User[]; latestMessage: App.DM })[];
+		channels: (DMChannel & { participants?: App.User[]; latestMessage?: App.DM })[];
 	}
 
 	const { children, id, channels }: Props = $props();
@@ -38,16 +38,16 @@
 					{/each}
 				</div>
 				<div class="flex flex-col overflow-hidden">
-					<strong>{ch.latestMessage.sender?.username}</strong>
+					<strong>{ch.latestMessage!.sender?.username}</strong>
 					<span
 						class="text-muted-foreground w-full overflow-hidden text-sm text-ellipsis whitespace-nowrap"
 						use:twemoji>
-						{#if ch.latestMessage.type === 'general'}
-							{ch.latestMessage.message}
-						{:else if ch.latestMessage.type === 'join'}
-							<i>{ch.latestMessage.sender?.username} 님이 대화방에 들어왔습니다.</i>
-						{:else if ch.latestMessage.type === 'leave'}
-							<i>{ch.latestMessage.sender?.username} 님이 대화방에서 나갔습니다.</i>
+						{#if ch.latestMessage!.type === 'general'}
+							{ch.latestMessage!.message}
+						{:else if ch.latestMessage!.type === 'join'}
+							<i>{ch.latestMessage!.sender?.username} 님이 대화방에 들어왔습니다.</i>
+						{:else if ch.latestMessage!.type === 'leave'}
+							<i>{ch.latestMessage!.sender?.username} 님이 대화방에서 나갔습니다.</i>
 						{/if}
 					</span>
 				</div>

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -26,8 +26,8 @@
 
 	let channels = $state(prefetchChannels);
 
-	source('/dm/sse')
-		.select('message')
+	source('/sse')
+		.select('dmSent')
 		.subscribe((message) => {
 			if (!message) return;
 			const parsed = JSON.parse(message);

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -13,7 +13,7 @@
 		channels: (DMChannel & { participants?: App.User[]; latestMessage?: App.DM })[];
 	}
 
-	const { children, channels }: Props = $props();
+	const { children, channels: prefetchChannels }: Props = $props();
 
 	let id = $state<Optional<string>>(undefined);
 
@@ -24,10 +24,20 @@
 	let user = $state<App.User>(null);
 	userStore.subscribe((v) => (user = v));
 
+	let channels = $state(prefetchChannels);
+
 	source('/dm/sse')
 		.select('message')
 		.subscribe((message) => {
-			if (message) console.log(JSON.parse(message));
+			if (!message) return;
+			const parsed = JSON.parse(message);
+
+			const channel = channels.find((ch) => ch.id === parsed.channelId);
+			if (!channel) return;
+
+			channel.latestMessage = parsed.dms[0];
+
+			console.log(channel, JSON.parse(message));
 		});
 </script>
 

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -5,6 +5,7 @@
 	import type { DMChannel } from '$lib/server/db/schema';
 	import { twemoji } from 'twemoji-svelte-action';
 	import { beforeNavigate } from '$app/navigation';
+	import { User } from 'lucide-svelte';
 
 	interface Props extends ReturnType<typeof $props> {
 		id?: string;
@@ -39,12 +40,20 @@
 						'hover:bg-accent hover:text-accent-foreground',
 				)}>
 				<div class="flex -space-x-5">
-					{#each participants || [] as participant}
-						<UserAvatar class="size-9" user={participant} />
-					{/each}
+					{#if participants && participants.length > 0}
+						{#each participants as participant}
+							<UserAvatar class="size-9" user={participant} />
+						{/each}
+					{:else}
+						<User class="size-9" />
+					{/if}
 				</div>
 				<div class="flex flex-col overflow-hidden">
-					<strong>{participants.map((v) => v!.username).join(', ')}</strong>
+					<strong>
+						{participants && participants.length > 0
+							? participants.map((v) => v!.username).join(', ')
+							: '다른 참여자 없음'}
+					</strong>
 					<span
 						class="text-muted-foreground w-full overflow-hidden text-sm text-ellipsis whitespace-nowrap"
 						use:twemoji>

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -4,13 +4,20 @@
 	import { cn } from '$lib/utils';
 	import type { DMChannel } from '$lib/server/db/schema';
 	import { twemoji } from 'twemoji-svelte-action';
+	import { beforeNavigate } from '$app/navigation';
 
 	interface Props extends ReturnType<typeof $props> {
 		id?: string;
 		channels: (DMChannel & { participants?: App.User[]; latestMessage?: App.DM })[];
 	}
 
-	const { children, id, channels }: Props = $props();
+	const { children, channels }: Props = $props();
+
+	let id = $state<Optional<string>>(undefined);
+
+	beforeNavigate((nav) => {
+		id = nav.to?.route.id?.startsWith('/dm') ? nav.to.params?.id : undefined;
+	});
 
 	let user = $state<App.User>(null);
 	userStore.subscribe((v) => (user = v));

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -42,7 +42,7 @@
 				<div class="flex -space-x-5">
 					{#if participants && participants.length > 0}
 						{#each participants as participant}
-							<UserAvatar class="size-9" user={participant} />
+							<UserAvatar class="size-9" user={participant} withoutLink />
 						{/each}
 					{:else}
 						<User class="size-9" />

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -2,11 +2,12 @@
 	import { userStore } from '$lib/context';
 	import UserAvatar from '$stories/components/Avatar.svelte';
 	import { cn } from '$lib/utils';
-	import type { DMChannel, DMParticipant } from '$lib/server/db/schema';
+	import type { DMChannel } from '$lib/server/db/schema';
+	import { twemoji } from 'twemoji-svelte-action';
 
 	interface Props extends ReturnType<typeof $props> {
 		id?: string;
-		channels: (DMChannel & { participants?: App.User[] })[];
+		channels: (DMChannel & { participants?: App.User[]; latestMessage: App.DM })[];
 	}
 
 	const { children, id, channels }: Props = $props();
@@ -29,7 +30,6 @@
 					(id === ch.id && 'bg-primary/60 text-primary-foreground') ||
 						'hover:bg-accent hover:text-accent-foreground',
 				)}>
-				<!-- TODO: 마지막 메시지 가져오기 -->
 				<div class="flex -space-x-5">
 					{#each ch.participants || [] as participant}
 						{#if participant!.id !== user!.id}
@@ -38,13 +38,19 @@
 					{/each}
 				</div>
 				<div class="flex flex-col overflow-hidden">
-					<strong>{user?.username}</strong>
+					<strong>{ch.latestMessage.sender?.username}</strong>
 					<span
-						class="text-muted-foreground w-full overflow-hidden text-sm text-ellipsis whitespace-nowrap">
-						고양이 고양이 고양이 고양이 고양이 고양이
+						class="text-muted-foreground w-full overflow-hidden text-sm text-ellipsis whitespace-nowrap"
+						use:twemoji>
+						{#if ch.latestMessage.type === 'general'}
+							{ch.latestMessage.message}
+						{:else if ch.latestMessage.type === 'join'}
+							<i>{ch.latestMessage.sender?.username} 님이 대화방에 들어왔습니다.</i>
+						{:else if ch.latestMessage.type === 'leave'}
+							<i>{ch.latestMessage.sender?.username} 님이 대화방에서 나갔습니다.</i>
+						{/if}
 					</span>
 				</div>
-				<!-- 여기까지 -->
 			</a>
 		{/each}
 	</nav>

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -42,7 +42,9 @@
 						class="text-muted-foreground w-full overflow-hidden text-sm text-ellipsis whitespace-nowrap"
 						use:twemoji>
 						{#if ch.latestMessage!.type === 'general'}
-							{ch.latestMessage!.sender!.username}: {ch.latestMessage!.message}
+							{ch.latestMessage!.sender!.id === user!.id
+								? '나'
+								: ch.latestMessage!.sender!.username}: {ch.latestMessage!.message}
 						{:else if ch.latestMessage!.type === 'join'}
 							<i>{ch.latestMessage!.sender?.username} 님이 대화방에 들어왔습니다.</i>
 						{:else if ch.latestMessage!.type === 'leave'}

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -4,27 +4,22 @@
 	import { cn } from '$lib/utils';
 	import type { DMChannel } from '$lib/server/db/schema';
 	import { twemoji } from 'twemoji-svelte-action';
-	import { beforeNavigate } from '$app/navigation';
+	import { beforeNavigate, invalidateAll } from '$app/navigation';
 	import { User } from 'lucide-svelte';
 	import { source } from 'sveltekit-sse';
+	import { page } from '$app/state';
+	import { tick } from 'svelte';
 
 	interface Props extends ReturnType<typeof $props> {
-		id?: string;
 		channels: (DMChannel & { participants?: App.User[]; latestMessage?: App.DM })[];
 	}
 
-	const { children, channels: prefetchChannels }: Props = $props();
+	const { children, channels }: Props = $props();
 
-	let id = $state<Optional<string>>(undefined);
-
-	beforeNavigate((nav) => {
-		id = nav.to?.route.id?.startsWith('/dm') ? nav.to.params?.id : undefined;
-	});
+	const id = page.params.id;
 
 	let user = $state<App.User>(null);
 	userStore.subscribe((v) => (user = v));
-
-	let channels = $state(prefetchChannels);
 
 	source('/sse')
 		.select('dmSent')
@@ -35,7 +30,23 @@
 			const channel = channels.find((ch) => ch.id === parsed.channelId);
 			if (!channel) return;
 
-			channel.latestMessage = parsed.dms[0];
+			invalidateAll();
+		});
+
+	source('/sse')
+		.select('join')
+		.subscribe((message) => {
+			if (!message) return;
+			console.log(message);
+			invalidateAll();
+		});
+
+	source('/sse')
+		.select('leave')
+		.subscribe((message) => {
+			if (!message) return;
+			console.log(message);
+			invalidateAll();
 		});
 </script>
 

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -2,11 +2,11 @@
 	import { userStore } from '$lib/context';
 	import UserAvatar from '$stories/components/Avatar.svelte';
 	import { cn } from '$lib/utils';
-	import type { DMChannel } from '$lib/server/db/schema';
+	import type { DMChannel, DMParticipant } from '$lib/server/db/schema';
 
 	interface Props extends ReturnType<typeof $props> {
 		id?: string;
-		channels: DMChannel[];
+		channels: (DMChannel & { participants?: App.User[] })[];
 	}
 
 	const { children, id, channels }: Props = $props();
@@ -29,12 +29,18 @@
 					(id === ch.id && 'bg-primary/60 text-primary-foreground') ||
 						'hover:bg-accent hover:text-accent-foreground',
 				)}>
-				<!-- TODO: 참가자 목록과 마지막 메시지 가져오기 -->
-				<UserAvatar class="size-9" {user} />
-				<div class="flex flex-col">
+				<!-- TODO: 마지막 메시지 가져오기 -->
+				<div class="flex -space-x-5">
+					{#each ch.participants || [] as participant}
+						{#if participant!.id !== user!.id}
+							<UserAvatar class="size-9" user={participant} />
+						{/if}
+					{/each}
+				</div>
+				<div class="flex flex-col overflow-hidden">
 					<strong>{user?.username}</strong>
 					<span
-						class="text-muted-foreground w-47 overflow-hidden text-sm text-ellipsis whitespace-nowrap">
+						class="text-muted-foreground w-full overflow-hidden text-sm text-ellipsis whitespace-nowrap">
 						고양이 고양이 고양이 고양이 고양이 고양이
 					</span>
 				</div>

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -6,6 +6,7 @@
 	import { twemoji } from 'twemoji-svelte-action';
 	import { beforeNavigate } from '$app/navigation';
 	import { User } from 'lucide-svelte';
+	import { source } from 'sveltekit-sse';
 
 	interface Props extends ReturnType<typeof $props> {
 		id?: string;
@@ -22,6 +23,12 @@
 
 	let user = $state<App.User>(null);
 	userStore.subscribe((v) => (user = v));
+
+	source('/dm/sse')
+		.select('message')
+		.subscribe((message) => {
+			if (message) console.log(JSON.parse(message));
+		});
 </script>
 
 <div class={cn('w-ful flex max-md:flex-col', (!id && 'md:h-[90vh]') || 'h-[90vh]')}>

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -16,8 +16,6 @@
 
 	const { children, channels }: Props = $props();
 
-	const id = page.params.id;
-
 	let user = $state<App.User>(null);
 	userStore.subscribe((v) => (user = v));
 
@@ -50,11 +48,11 @@
 		});
 </script>
 
-<div class={cn('w-ful flex max-md:flex-col', (!id && 'md:h-[90vh]') || 'h-[90vh]')}>
+<div class={cn('w-ful flex max-md:flex-col', (!page.params.id && 'md:h-[90vh]') || 'h-[90vh]')}>
 	<nav
 		class={cn(
 			'bg-background mt-16 w-70 flex-none overflow-y-auto max-md:w-full',
-			!!id && 'max-md:hidden',
+			!!page.params.id && 'max-md:hidden',
 		)}>
 		{#each channels as ch}
 			{@const participants = (ch.participants || []).filter((v) => v!.id !== user!.id)}
@@ -62,7 +60,7 @@
 				href="/dm/{ch.id}"
 				class={cn(
 					'm-2 flex items-center space-x-2 border p-2',
-					(id === ch.id && 'bg-primary/60 text-primary-foreground') ||
+					(page.params.id === ch.id && 'bg-primary/60 text-primary-foreground') ||
 						'hover:bg-accent hover:text-accent-foreground',
 				)}>
 				<div class="flex -space-x-5">

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -36,8 +36,6 @@
 			if (!channel) return;
 
 			channel.latestMessage = parsed.dms[0];
-
-			console.log(channel, JSON.parse(message));
 		});
 </script>
 

--- a/src/stories/dm/Layout.svelte
+++ b/src/stories/dm/Layout.svelte
@@ -23,6 +23,7 @@
 			!!id && 'max-md:hidden',
 		)}>
 		{#each channels as ch}
+			{@const participants = (ch.participants || []).filter((v) => v!.id !== user!.id)}
 			<a
 				href="/dm/{ch.id}"
 				class={cn(
@@ -31,19 +32,17 @@
 						'hover:bg-accent hover:text-accent-foreground',
 				)}>
 				<div class="flex -space-x-5">
-					{#each ch.participants || [] as participant}
-						{#if participant!.id !== user!.id}
-							<UserAvatar class="size-9" user={participant} />
-						{/if}
+					{#each participants || [] as participant}
+						<UserAvatar class="size-9" user={participant} />
 					{/each}
 				</div>
 				<div class="flex flex-col overflow-hidden">
-					<strong>{ch.latestMessage!.sender?.username}</strong>
+					<strong>{participants.map((v) => v!.username).join(', ')}</strong>
 					<span
 						class="text-muted-foreground w-full overflow-hidden text-sm text-ellipsis whitespace-nowrap"
 						use:twemoji>
 						{#if ch.latestMessage!.type === 'general'}
-							{ch.latestMessage!.message}
+							{ch.latestMessage!.sender!.username}: {ch.latestMessage!.message}
 						{:else if ch.latestMessage!.type === 'join'}
 							<i>{ch.latestMessage!.sender?.username} 님이 대화방에 들어왔습니다.</i>
 						{:else if ch.latestMessage!.type === 'leave'}

--- a/src/stories/dm/Message.svelte
+++ b/src/stories/dm/Message.svelte
@@ -130,7 +130,6 @@
 	{/if}
 	{#if dm.type === 'general'}
 		{@const sentAtString = formatDatetimeString(dm.sentAt)}
-		{@const v = console.log(formatDatetimeString(sentAtOfNext), sentAtString)}
 		<div class={cn('relative flex flex-col', dir === Direction.SEND ? 'items-end' : 'items-start')}>
 			{#if dm.message || !!dm.relatedPost}
 				{@const message = dm.message || ''}

--- a/src/stories/dm/Message.svelte
+++ b/src/stories/dm/Message.svelte
@@ -114,6 +114,8 @@
 			// 	openErrorOnBeginDM = true;
 		}
 	};
+
+	const sentAtString = formatDatetimeString(dm.sentAt);
 </script>
 
 <article
@@ -129,7 +131,6 @@
 		{/if}
 	{/if}
 	{#if dm.type === 'general'}
-		{@const sentAtString = formatDatetimeString(dm.sentAt)}
 		<div class={cn('relative flex flex-col', dir === Direction.SEND ? 'items-end' : 'items-start')}>
 			{#if dm.message || !!dm.relatedPost}
 				{@const message = dm.message || ''}

--- a/src/stories/dm/Message.svelte
+++ b/src/stories/dm/Message.svelte
@@ -6,6 +6,8 @@
 </script>
 
 <script lang="ts">
+	import { deserialize } from '$app/forms';
+
 	import Muted from '$lib/components/typo/muted.svelte';
 	import Badge from '$lib/components/ui/badge/badge.svelte';
 	import { Button } from '$lib/components/ui/button';
@@ -31,6 +33,7 @@
 		) => void;
 		tabindex?: number;
 		onReply?: (message: App.DM) => void;
+		onReact?: (messageId: string, emoji: Emoji | undefined) => void;
 	}
 
 	const {
@@ -43,6 +46,7 @@
 		onScrollToDM = () => {},
 		onOpenEmojiList = () => {},
 		onReply = () => {},
+		onReact = () => {},
 	}: Props = $props();
 
 	const sameSenderAsPrev =
@@ -98,8 +102,20 @@
 		articleElement.addEventListener('mouseleave', () => (isMouseHover = false));
 	});
 
-	const onEmoji: EmojiEventHandler = (emoji) => {
-		console.log(emoji); // TODO: 이모티콘 반응 등록
+	const onEmoji: EmojiEventHandler = async (emoji) => {
+		const body = new FormData();
+		body.append('messageId', dm.id);
+		if (emoji) body.append('emoji', emoji);
+
+		const result = await fetch('?/react', { method: 'post', body })
+			.then((r) => r.text())
+			.then((r) => deserialize(r));
+
+		if (result.type === 'success') {
+			onReact(dm.id, emoji);
+			// } else {
+			// 	openErrorOnBeginDM = true;
+		}
 	};
 </script>
 
@@ -190,8 +206,8 @@
 								<div class="mt-2 space-x-2 text-right">
 									{#each reactions as [emoji, num]}
 										<Badge
-											variant={emoji === dm.myReaction ? 'default' : 'outline'}
-											class="space-x-1">
+											variant={emoji === dm.myReaction ? 'default' : 'secondary'}
+											class="border-secondary space-x-1 border">
 											<span>{emoji}</span>
 											<span>{num}</span>
 										</Badge>

--- a/src/stories/dm/Message.svelte
+++ b/src/stories/dm/Message.svelte
@@ -23,8 +23,6 @@
 	interface Props extends ReturnType<typeof $props> {
 		dir: Direction;
 		dm: App.DM;
-		prev?: App.DM;
-		next?: App.DM;
 		onScrollToDM?: (id: string) => void;
 		onOpenEmojiList?: (
 			event: MouseEvent & { currentTarget: EventTarget & HTMLElement },
@@ -34,25 +32,24 @@
 		tabindex?: number;
 		onReply?: (message: App.DM) => void;
 		onReact?: (messageId: string, emoji: Emoji | undefined) => void;
+		sameSenderAsPrev?: boolean;
+		sameSenderAsNext?: boolean;
+		sentAtOfNext?: Date;
 	}
 
 	const {
 		dir,
 		dm,
-		prev,
-		next,
 		id,
 		tabindex = 0,
 		onScrollToDM = () => {},
 		onOpenEmojiList = () => {},
 		onReply = () => {},
 		onReact = () => {},
+		sameSenderAsNext = false,
+		sameSenderAsPrev = false,
+		sentAtOfNext = new Date(0),
 	}: Props = $props();
-
-	const sameSenderAsPrev =
-		!['join', 'leave'].includes(prev?.type || '') && prev?.sender?.id === dm.sender?.id;
-	const sameSenderAsNext =
-		!['join', 'leave'].includes(next?.type || '') && next?.sender?.id === dm.sender?.id;
 
 	const dataSource = $state(
 		(dm.type === 'general' &&
@@ -133,6 +130,7 @@
 	{/if}
 	{#if dm.type === 'general'}
 		{@const sentAtString = formatDatetimeString(dm.sentAt)}
+		{@const v = console.log(formatDatetimeString(sentAtOfNext), sentAtString)}
 		<div class={cn('relative flex flex-col', dir === Direction.SEND ? 'items-end' : 'items-start')}>
 			{#if dm.message || !!dm.relatedPost}
 				{@const message = dm.message || ''}
@@ -257,7 +255,7 @@
 					{/each}
 				</div>
 			{/if}
-			{#if !sameSenderAsNext || formatDatetimeString(next?.sentAt || new Date(0)) !== sentAtString}
+			{#if !sameSenderAsNext || formatDatetimeString(sentAtOfNext) !== sentAtString}
 				<!-- 다음 사용자와 같은 경우 보낸 시간 미표시 -->
 				<Muted class="mx-3 flex-none">{sentAtString}</Muted>
 			{/if}

--- a/src/stories/dm/Message.svelte
+++ b/src/stories/dm/Message.svelte
@@ -30,6 +30,7 @@
 			option: { autoClose?: boolean; value?: Emoji },
 		) => void;
 		tabindex?: number;
+		onReply?: (message: App.DM) => void;
 	}
 
 	const {
@@ -41,6 +42,7 @@
 		tabindex = 0,
 		onScrollToDM = () => {},
 		onOpenEmojiList = () => {},
+		onReply = () => {},
 	}: Props = $props();
 
 	const sameSenderAsPrev =
@@ -249,7 +251,7 @@
 					!(isFocused || isMouseHover) && 'hidden',
 					dir === Direction.SEND ? '-left-2' : '-right-2',
 				)}>
-				<Button size="icon" variant="ghost" class="size-8 border">
+				<Button size="icon" variant="ghost" class="size-8 border" onclick={() => onReply(dm)}>
 					<!-- 답글 -->
 					<CornerDownRight />
 				</Button>

--- a/src/stories/portfolio/View.svelte
+++ b/src/stories/portfolio/View.svelte
@@ -101,7 +101,10 @@
 						<Table.Head class="w-[8em]">작성자</Table.Head>
 						<Table.Cell>
 							<Button variant="link" class="text-inherit" href="/user/{article.author.id}">
-								<Avatar class="inline-block h-6 w-6 align-middle" user={article.author} />
+								<Avatar
+									class="inline-block h-6 w-6 align-middle"
+									user={article.author}
+									withoutLink />
 								{article.author.username}
 							</Button>
 						</Table.Cell>

--- a/src/stories/request/View.svelte
+++ b/src/stories/request/View.svelte
@@ -91,7 +91,10 @@
 						<Table.Head class="w-[8em]">작성자</Table.Head>
 						<Table.Cell>
 							<Button variant="link" class="text-inherit" href="/user/{article.author.id}">
-								<Avatar class="inline-block h-6 w-6 align-middle" user={article.author} />
+								<Avatar
+									class="inline-block h-6 w-6 align-middle"
+									user={article.author}
+									withoutLink />
 								{article.author.username}
 							</Button>
 						</Table.Cell>


### PR DESCRIPTION
- resolves #80
  - 대화방 목록 표시: 로그인한 사용자 외 다른 참가자 목록 및 대화방의 최신 메시지 표시
  - 대화방 페이지 기능 구현
    - 대화방 정보 획득
    - 메시지 전송 기능 구현
      - 일반 메시지
      - 이모티콘 단독 메시지
      - 답장형 메시지
      - 이미지 첨부된 메시지
    - 이모티콘 반응 설정 및 삭제
    - 대화방 나가기 기능 구현
    - 대화방에 혼자만 남은 경우의 대응 구현
    - 메시지 목록 페이징 구현
  - 읽음 확인 기능 추가
  - SSE 및 pg-notify를 통한 사용자 간 메시지 교환 구현
    - 메시지 송수신 시 대화방 목록 상 각 대화방의 최신 메시지 변경 및 대화 목록에 반영
    - 대화방에 혼자만 남은 경우 실시간 대응 구현
- 기타
  - 채널 생성 시 GENERAL 타입이 아닌 경우 관련 게시물 정보도 같이 고려하도록 변경
  - DM 관련 공통 코드에 트랜잭션 적용
  - 클라이언트 측에서 직접 `id` param 감지
  - 아바타 클릭 시 해당 사용자 프로필로 이동하도록 변경