### PR TITLE
#82: 의뢰 관련 DM 기능 구현

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -17,7 +17,7 @@
 		--hsl-stone-50: 60 9.1% 97.8%;
 
 		--hsl-light-primary: 29.52 83% 25%;
-		--hsl-dark-primary: 29.52 83% 25%;
+		--hsl-dark-primary: 34.4 100% 33%;
 	}
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -89,6 +89,7 @@
 	}
 	body {
 		@apply bg-background text-foreground;
+		background-color: hsl(var(--hsl-stone-900));
 		/* background-image: url('/background-pattern-light.png'); /* Made by [Atle Mo](http://www.atlemo.com/) */
 	}
 

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -1,4 +1,4 @@
-import { DMChannelType, UserRelationship } from '@app';
+import { ArticleType, DMChannelType, UserRelationship } from '@app';
 import { db, generateID, table } from '../db';
 import {
 	and,
@@ -37,14 +37,14 @@ type Transaction =
 export const createDMChannel = async (
 	mainTx: Transaction,
 	type = DMChannelType.GENERAL,
-	relatedArticle?: string,
+	relatedArticle?: App.Articles,
 ) => {
 	const channelId = generateID();
 
 	await mainTx.insert(table.dmChannel).values({
 		id: channelId,
 		type,
-		relatedArticle,
+		relatedArticle: relatedArticle?.id,
 	});
 
 	return channelId;
@@ -260,7 +260,7 @@ export const beginDMProc = async (
 	fromUser: NonNullable<App.User>,
 	toUser: NonNullable<App.User>,
 	type = DMChannelType.GENERAL,
-	relatedArticle?: string,
+	relatedArticle?: App.Articles,
 ) => {
 	// 자기 자신과 DM할 수 없음
 	if (fromUser.id === toUser.id) throw new Error('Cannot chat with yourself', { cause: 400 });
@@ -277,7 +277,7 @@ export const beginDMProc = async (
 	// 이미 채널이 있는 경우 해당 채널의 ID 반환
 	const result = (
 		await getDMChannels(fromUser.id, toUser.id, (_, ch) =>
-			and(eq(ch.type, type), relatedArticle ? eq(ch.relatedArticle, relatedArticle) : undefined),
+			and(eq(ch.type, type), relatedArticle ? eq(ch.relatedArticle, relatedArticle.id) : undefined),
 		)
 	).at(0);
 	if (result) return result.id;
@@ -292,6 +292,24 @@ export const beginDMProc = async (
 
 		telecom.notify(fromUser.id, { event: 'join', channelId, userId: fromUser.id });
 		telecom.notify(toUser.id, { event: 'join', channelId, userId: toUser.id });
+
+		switch (type) {
+			case DMChannelType.GENERAL:
+				/* noop */
+				break;
+			case DMChannelType.REQUEST:
+				await send(tx, channelId, fromUser, {
+					type: 'general',
+					relatedPost: {
+						type: ArticleType.REQUEST,
+						article: relatedArticle,
+					},
+				} as App.DM & App.GeneralDM);
+				break;
+			case DMChannelType.COMMISSION:
+				// TODO: 커미션 관련 DM인 경우 구현
+				break;
+		}
 
 		// 해당 채널 ID를 반환
 		return channelId;
@@ -325,7 +343,7 @@ export const getDMChannelInfo = async (channelId: string, sender: NonNullable<Ap
 	return {
 		...channelInfo,
 		participants: participants,
-		isAbleToSend: await isAbleToSend(channelId, sender),
+		isAbleToSend: await isAbleToSend(db, channelId, sender),
 	};
 };
 
@@ -430,55 +448,62 @@ export const get = async (channelId: string, before: Date, me: NonNullable<App.U
 	}));
 };
 
-const relationshipToUser = alias(table.userRelationship, 'relationshipToUser');
-const relationshipFromUser = alias(table.userRelationship, 'relationshipFromUser');
+export const isAbleToSend = async (
+	mainTx: Transaction,
+	channelId: string,
+	sender: NonNullable<App.User>,
+) => {
+	const relationshipToUser = alias(table.userRelationship, 'relationshipToUser');
+	const relationshipFromUser = alias(table.userRelationship, 'relationshipFromUser');
 
-const ableToSendSubquery = db
-	.select({
-		participant: table.dmParticipant.participantId,
-		relationshipToUser: aliasedColumn(relationshipToUser.relationship, 'relationshipToUser'),
-		relationshipFromUser: aliasedColumn(relationshipFromUser.relationship, 'relationshipFromUser'),
-	})
-	.from(table.dmParticipant)
-	.where(
-		and(
-			eq(table.dmParticipant.channelId, sql.placeholder('channelId')),
-			ne(table.dmParticipant.participantId, sql.placeholder('senderId')),
-		),
-	)
-	.leftJoin(
-		relationshipToUser,
-		and(
-			eq(relationshipToUser.from, sql.placeholder('senderId')),
-			eq(relationshipToUser.to, table.dmParticipant.participantId),
-		),
-	)
-	.leftJoin(
-		relationshipFromUser,
-		and(
-			eq(relationshipFromUser.to, sql.placeholder('senderId')),
-			eq(relationshipFromUser.from, table.dmParticipant.participantId),
-		),
-	)
-	.as('sq');
-
-const ableToSendQuery = db
-	.select()
-	.from(ableToSendSubquery)
-	.where(
-		and(
-			or(
-				isNull(ableToSendSubquery.relationshipFromUser),
-				ne(ableToSendSubquery.relationshipFromUser, UserRelationship.BLOCKED),
+	const ableToSendSubquery = mainTx
+		.select({
+			participant: table.dmParticipant.participantId,
+			relationshipToUser: aliasedColumn(relationshipToUser.relationship, 'relationshipToUser'),
+			relationshipFromUser: aliasedColumn(
+				relationshipFromUser.relationship,
+				'relationshipFromUser',
 			),
-			or(
-				isNull(ableToSendSubquery.relationshipToUser),
-				ne(ableToSendSubquery.relationshipToUser, UserRelationship.BLOCKED),
+		})
+		.from(table.dmParticipant)
+		.where(
+			and(
+				eq(table.dmParticipant.channelId, sql.placeholder('channelId')),
+				ne(table.dmParticipant.participantId, sql.placeholder('senderId')),
 			),
-		),
-	);
+		)
+		.leftJoin(
+			relationshipToUser,
+			and(
+				eq(relationshipToUser.from, sql.placeholder('senderId')),
+				eq(relationshipToUser.to, table.dmParticipant.participantId),
+			),
+		)
+		.leftJoin(
+			relationshipFromUser,
+			and(
+				eq(relationshipFromUser.to, sql.placeholder('senderId')),
+				eq(relationshipFromUser.from, table.dmParticipant.participantId),
+			),
+		)
+		.as('sq');
 
-export const isAbleToSend = async (channelId: string, sender: NonNullable<App.User>) => {
+	const ableToSendQuery = mainTx
+		.select()
+		.from(ableToSendSubquery)
+		.where(
+			and(
+				or(
+					isNull(ableToSendSubquery.relationshipFromUser),
+					ne(ableToSendSubquery.relationshipFromUser, UserRelationship.BLOCKED),
+				),
+				or(
+					isNull(ableToSendSubquery.relationshipToUser),
+					ne(ableToSendSubquery.relationshipToUser, UserRelationship.BLOCKED),
+				),
+			),
+		);
+
 	const result = await ableToSendQuery.execute({
 		channelId,
 		senderId: sender.id,
@@ -488,6 +513,7 @@ export const isAbleToSend = async (channelId: string, sender: NonNullable<App.Us
 };
 
 export const send = async (
+	mainTx: Transaction,
 	channelId: string,
 	sender: NonNullable<App.User>,
 	content: Omit<App.DM, 'id' | 'sentAt' | 'sender'>,
@@ -496,9 +522,10 @@ export const send = async (
 	const messageId = generateID();
 	const sentAt = new Date();
 
-	if (!(await isAbleToSend(channelId, sender))) throw Error('Not able to send', { cause: 406 });
+	if (!(await isAbleToSend(mainTx, channelId, sender)))
+		throw Error('Not able to send', { cause: 406 });
 
-	const _relatedMessage = await db.transaction(async (tx) => {
+	const _relatedMessage = await mainTx.transaction(async (tx) => {
 		await tx.insert(table.dmContent).values({
 			channelId,
 			messageId,
@@ -568,7 +595,7 @@ export const send = async (
 	];
 
 	(
-		await db
+		await mainTx
 			.select({ uid: table.dmParticipant.participantId })
 			.from(table.dmParticipant)
 			.where(eq(table.dmParticipant.channelId, channelId))

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -63,7 +63,7 @@ export const joinToChannel = async (
 
 		const dm: App.DM = {
 			id: generateID(),
-			type: 'leave',
+			type: 'join',
 			sentAt: new Date(),
 			sender: user,
 		};
@@ -282,38 +282,40 @@ export const beginDMProc = async (
 	).at(0);
 	if (result) return result.id;
 
-	return await db.transaction(async (tx) => {
-		// 채널 생성
-		const channelId = await createDMChannel(tx, type, relatedArticle);
+	return await db
+		.transaction(async (tx) => {
+			// 채널 생성
+			const channelId = await createDMChannel(tx, type, relatedArticle);
 
-		// 해당 채널에 가입
-		await joinToChannel(tx, fromUser, channelId);
-		await joinToChannel(tx, toUser, channelId);
+			// 해당 채널에 가입
+			await joinToChannel(tx, fromUser, channelId);
+			await joinToChannel(tx, toUser, channelId);
 
-		telecom.notify(fromUser.id, { event: 'join', channelId, userId: fromUser.id });
-		telecom.notify(toUser.id, { event: 'join', channelId, userId: toUser.id });
+			switch (type) {
+				case DMChannelType.GENERAL:
+					/* noop */
+					break;
+				case DMChannelType.REQUEST:
+					await send(tx, channelId, fromUser, {
+						type: 'general',
+						relatedPost: {
+							type: ArticleType.REQUEST,
+							article: relatedArticle,
+						},
+					} as App.DM & App.GeneralDM);
+					break;
+				case DMChannelType.COMMISSION:
+					// TODO: 커미션 관련 DM인 경우 구현
+					break;
+			}
 
-		switch (type) {
-			case DMChannelType.GENERAL:
-				/* noop */
-				break;
-			case DMChannelType.REQUEST:
-				await send(tx, channelId, fromUser, {
-					type: 'general',
-					relatedPost: {
-						type: ArticleType.REQUEST,
-						article: relatedArticle,
-					},
-				} as App.DM & App.GeneralDM);
-				break;
-			case DMChannelType.COMMISSION:
-				// TODO: 커미션 관련 DM인 경우 구현
-				break;
-		}
+			telecom.notify(fromUser.id, { event: 'join', channelId, userId: fromUser.id });
+			telecom.notify(toUser.id, { event: 'join', channelId, userId: toUser.id });
 
-		// 해당 채널 ID를 반환
-		return channelId;
-	});
+			// 해당 채널 ID를 반환
+			return channelId;
+		})
+		.then((channelId) => new Promise((resolve) => setTimeout(() => resolve(channelId), 300))); // 채널 생성 후 1초 뒤에 반환
 };
 
 export const getDMChannelInfo = async (channelId: string, sender: NonNullable<App.User>) => {

--- a/src/lib/server/common/dm.ts
+++ b/src/lib/server/common/dm.ts
@@ -329,6 +329,42 @@ export const getDMChannelInfo = async (channelId: string, sender: NonNullable<Ap
 			.where(eq(table.dmChannel.id, channelId))
 	).at(0);
 
+	let relatedArticle: App.Articles | undefined = undefined;
+
+	switch (channelInfo?.type) {
+		case DMChannelType.GENERAL:
+			/* noop */
+			break;
+		case DMChannelType.REQUEST:
+			relatedArticle = (
+				await db
+					.select({
+						id: table.commissionRequest.id,
+						thumbnail: table.commissionRequest.thumbnail,
+						title: table.commissionRequest.title,
+						author: {
+							id: table.user.id,
+							username: table.user.username,
+							profileImage: table.user.profileImage,
+							email: table.user.email,
+							preferences: table.user.preferences,
+							profile: table.user.profile,
+							birthday: table.user.birthday,
+							authExpiresAt: table.user.authExpiresAt,
+						},
+						category: table.commissionRequest.category,
+						tags: table.commissionRequest.tags,
+					})
+					.from(table.commissionRequest)
+					.where(eq(table.commissionRequest.id, channelInfo.relatedArticle!))
+					.innerJoin(table.user, eq(table.commissionRequest.author, table.user.id))
+			).at(0);
+			break;
+		case DMChannelType.COMMISSION:
+			// TODO: 커미션 관련 DM 채널인 경우의 동작 구현
+			break;
+	}
+
 	const participants = (
 		await db
 			.select({
@@ -344,6 +380,7 @@ export const getDMChannelInfo = async (channelId: string, sender: NonNullable<Ap
 
 	return {
 		...channelInfo,
+		relatedArticle,
 		participants: participants,
 		isAbleToSend: await isAbleToSend(db, channelId, sender),
 	};

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -16,7 +16,9 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 	try {
 		const [requests] = await Promise.all(
-			articlesPerType([ArticleType.REQUEST], {}, locals.user).map((v) => v?.limit(10)),
+			articlesPerType([ArticleType.REQUEST], {}, locals.user).map((v) =>
+				v?.orderBy(desc(v._.selectedFields.modifyDate)).limit(10),
+			),
 		);
 
 		return { requests };

--- a/src/routes/dm/[id]/+page.server.ts
+++ b/src/routes/dm/[id]/+page.server.ts
@@ -46,6 +46,7 @@ export const actions: Actions = {
 
 		try {
 			const dms = await dm.send(
+				db,
 				channelId,
 				locals.user,
 				{

--- a/src/routes/r/[id]/+page.server.ts
+++ b/src/routes/r/[id]/+page.server.ts
@@ -4,11 +4,14 @@ import { db } from '$lib/server/db';
 import * as table from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
 import { fail } from '@sveltejs/kit';
-import { AdultContents, ErrorCode, DMChannelType } from '@app';
+import { AdultContents, ErrorCode, DMChannelType, UserRelationship } from '@app';
 import { isAdult } from '$lib/utils';
 import { beginDMProc } from '$lib/server/common/dm';
+import * as relationship from '$lib/server/common/relationship';
 
-export const load = (async ({ params, locals }) => {
+export const load = (async ({ params, locals, depends }) => {
+	depends('r:info');
+
 	const id = params.id;
 
 	const article = (
@@ -59,8 +62,24 @@ export const load = (async ({ params, locals }) => {
 		}
 	}
 
+	let relationshipFromUser = UserRelationship.NONE;
+	let relationshipToUser = UserRelationship.NONE;
+
+	if (locals.user && locals.user.id !== article.author.id) {
+		try {
+			const result = await relationship.getRelationship(locals.user.id, article.author.id);
+
+			relationshipFromUser = result.fromUser;
+			relationshipToUser = result.toUser;
+		} catch (e) {
+			if (!(e instanceof Error) || e.cause !== 400) throw e;
+		}
+	}
+
 	return {
 		article,
+		relationshipFromUser,
+		relationshipToUser,
 	};
 }) satisfies PageServerLoad;
 

--- a/src/routes/r/[id]/+page.server.ts
+++ b/src/routes/r/[id]/+page.server.ts
@@ -4,8 +4,9 @@ import { db } from '$lib/server/db';
 import * as table from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
 import { fail } from '@sveltejs/kit';
-import { AdultContents, ErrorCode } from '@app';
+import { AdultContents, ErrorCode, DMChannelType } from '@app';
 import { isAdult } from '$lib/utils';
+import { beginDMProc } from '$lib/server/common/dm';
 
 export const load = (async ({ params, locals }) => {
 	const id = params.id;
@@ -92,5 +93,60 @@ export const actions: Actions = {
 		}
 
 		return { message: 'Deletion of the article completed' };
+	},
+
+	beginDM: async ({ locals, params }) => {
+		if (!locals.user) return fail(403, { message: 'Not logined' });
+
+		try {
+			const article = (
+				await db
+					.select({
+						id: table.commissionRequest.id,
+						thumbnail: table.commissionRequest.thumbnail,
+						title: table.commissionRequest.title,
+						author: {
+							id: table.user.id,
+							username: table.user.username,
+							profileImage: table.user.profileImage,
+							email: table.user.email,
+							preferences: table.user.preferences,
+							profile: table.user.profile,
+							birthday: table.user.birthday,
+							authExpiresAt: table.user.authExpiresAt,
+							status: table.user.status,
+						},
+						category: table.commissionRequest.category,
+						tags: table.commissionRequest.tags,
+						createDate: table.commissionRequest.createDate,
+						modifyDate: table.commissionRequest.modifyDate,
+						content: table.commissionRequest.content,
+						containsAdultContents: table.commissionRequest.containsAdultContents,
+						budget: table.commissionRequest.budget,
+						deadline: table.commissionRequest.deadline,
+						isForCommercial: table.commissionRequest.isForCommercial,
+						purpose: table.commissionRequest.purpose,
+						visibleOnlyToCommissioner: table.commissionRequest.visibleOnlyToCommissioner,
+					})
+					.from(table.commissionRequest)
+					.where(eq(table.commissionRequest.id, params.id))
+					.innerJoin(table.user, eq(table.commissionRequest.author, table.user.id))
+			).at(0);
+
+			if (!article) return fail(404, { message: 'No article found' });
+
+			const user = article.author;
+
+			const channelId = await beginDMProc(locals.user, user, DMChannelType.REQUEST, article);
+
+			return { channelId };
+		} catch (e) {
+			if (e instanceof Error) {
+				if (typeof e.cause === 'number') return fail(e.cause, { message: e.message });
+			}
+
+			console.error(e);
+			return fail(500, { message: 'An error has occurred' });
+		}
 	},
 };

--- a/src/routes/r/[id]/+page.svelte
+++ b/src/routes/r/[id]/+page.svelte
@@ -5,4 +5,7 @@
 	let { data }: { data: PageData } = $props();
 </script>
 
-<View article={data.article} />
+<View
+	article={data.article}
+	relationshipToUser={data.relationshipToUser}
+	relationshipFromUser={data.relationshipFromUser} />

--- a/src/stories/dm/Chat.svelte
+++ b/src/stories/dm/Chat.svelte
@@ -7,11 +7,18 @@
 	import { EllipsisVertical, Paperclip, SendHorizontal, SmilePlus, X } from 'lucide-svelte';
 	import Message, { Direction } from './Message.svelte';
 	import { userStore } from '$lib/context';
-	import { ArticleCategory, ArticleType, UserRelationship } from '@app';
+	import { ArticleCategory, ArticleType, DMChannelType, UserRelationship } from '@app';
 	import EmojiList, { type EmojiEventHandler } from '$stories/components/EmojiList.svelte';
 	import { goto, invalidate, invalidateAll, onNavigate } from '$app/navigation';
 	import type { Emoji } from 'emoji-type';
-	import { cn, formatDatetimeString, sanitizeHTML, twemoji, uploadImage } from '$lib/utils';
+	import {
+		cn,
+		formatDatetimeString,
+		getLinkPrefix,
+		sanitizeHTML,
+		twemoji,
+		uploadImage,
+	} from '$lib/utils';
 	import Muted from '$lib/components/typo/muted.svelte';
 	import UserAvatar from '$stories/components/Avatar.svelte';
 	import MediaListCarousel from '$stories/components/MediaListCarousel.svelte';
@@ -343,6 +350,22 @@
 			</DropdownMenu.Content>
 		</DropdownMenu.Root>
 	</H2>
+	{#if info && info.type && info.type !== DMChannelType.GENERAL}
+		{@const articleType =
+			info.type === DMChannelType.REQUEST
+				? ArticleType.REQUEST
+				: info.type === DMChannelType.COMMISSION
+					? ArticleType.COMMISSION
+					: undefined}
+		{@const href = articleType && `/${getLinkPrefix(articleType)}/${info.relatedArticle!.id}`}
+		{#if href}
+			<Muted class="mt-2">
+				관련 게시물: <Button {href} variant="link" target="_blank">
+					{info.relatedArticle!.title}
+				</Button>
+			</Muted>
+		{/if}
+	{/if}
 	<section
 		bind:this={container}
 		onscroll={onScrollContainer}

--- a/src/stories/request/View.svelte
+++ b/src/stories/request/View.svelte
@@ -17,6 +17,7 @@
 	import Tooltip from '$lib/components/tooltip/Tooltip.svelte';
 	import { EllipsisVertical, MessageSquare, Share2 } from 'lucide-svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import { toast } from 'svelte-sonner';
 
 	interface Props extends ReturnType<typeof $props> {
 		article: App.Request;
@@ -45,6 +46,15 @@
 		}
 
 		openAfterDeletionAlert = true;
+	};
+
+	// Article link copy
+	const onCopyArticleLink = () => {
+		navigator.clipboard.writeText(location.href).then(() => {
+			toast.success('게시물 링크가 복사되었습니다.', {
+				description: '원하는 곳에 붙여넣어 사용하시기 바랍니다.',
+			});
+		});
 	};
 </script>
 
@@ -150,8 +160,7 @@
 						</div>
 					{/snippet}
 				</Tooltip>
-				<Button size="icon" variant="outline"><Share2 /></Button>
-				<!--  onclick={onCopyProfileLink} -->
+				<Button size="icon" variant="outline" onclick={onCopyArticleLink}><Share2 /></Button>
 				<!-- TODO 구현 완료 시 재활성화
 				<DropdownMenu.Root>
 					<DropdownMenu.Trigger class="m-0 p-0">

--- a/src/stories/request/View.svelte
+++ b/src/stories/request/View.svelte
@@ -10,21 +10,24 @@
 	import Badge from '$lib/components/ui/badge/badge.svelte';
 	import { userStore } from '$lib/context';
 	import AlertDialog from '$stories/components/AlertDialog.svelte';
-	import { goto } from '$app/navigation';
+	import { goto, invalidate } from '$app/navigation';
 	import Ul from '$lib/components/typo/ul.svelte';
-	import { AdultContents } from '@app';
+	import { AdultContents, UserRelationship } from '@app';
 	import { page } from '$app/state';
 	import Tooltip from '$lib/components/tooltip/Tooltip.svelte';
 	import { EllipsisVertical, MessageSquare, Share2 } from 'lucide-svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { toast } from 'svelte-sonner';
 	import { deserialize } from '$app/forms';
+	import { source } from 'sveltekit-sse';
 
 	interface Props extends ReturnType<typeof $props> {
 		article: App.Request;
+		relationshipToUser: UserRelationship;
+		relationshipFromUser: UserRelationship;
 	}
 
-	const { article }: Props = $props();
+	const { article, relationshipFromUser, relationshipToUser }: Props = $props();
 
 	let me = $state<App.User>(null);
 	userStore.subscribe((v) => (me = v));
@@ -74,6 +77,21 @@
 			});
 		}
 	};
+
+	source('/sse')
+		.select('relationshipChanged')
+		.subscribe(async (message) => {
+			if (!message) return;
+			const parsed = JSON.parse(message);
+
+			if (!me) return;
+
+			if (
+				!(parsed.fromUser === me.id && parsed.toUser === article.author.id) &&
+				!(parsed.toUser === me.id && parsed.fromUser === article.author.id)
+			)
+				invalidate('r:info');
+		});
 </script>
 
 <svelte:head>
@@ -162,15 +180,18 @@
 		</section>
 		{#if me && article.author.id !== me.id}
 			<section class="flex">
-				<Tooltip class="w-full" text="차단했거나 차단된 경우 메시지를 보낼 수 없습니다">
-					<!-- disabled={relationshipFromUser !== UserRelationship.BLOCKED &&
-						relationshipToUser !== UserRelationship.BLOCKED} -->
+				<Tooltip
+					class="w-full"
+					text="차단했거나 차단된 경우 메시지를 보낼 수 없습니다"
+					disabled={relationshipFromUser !== UserRelationship.BLOCKED &&
+						relationshipToUser !== UserRelationship.BLOCKED}>
 					{#snippet child({ props })}
 						<div {...props} class="w-full">
-							<Button class="w-full flex-1" onclick={onBeginDM}>
-								<!-- disabled={relationshipFromUser === UserRelationship.BLOCKED ||
-									relationshipToUser === UserRelationship.BLOCKED ||
-									user.id === me?.id} -->
+							<Button
+								class="w-full flex-1"
+								onclick={onBeginDM}
+								disabled={relationshipFromUser === UserRelationship.BLOCKED ||
+									relationshipToUser === UserRelationship.BLOCKED}>
 								<MessageSquare />
 								이 의뢰에 관해 메시지하기
 							</Button>

--- a/src/stories/request/View.svelte
+++ b/src/stories/request/View.svelte
@@ -14,6 +14,9 @@
 	import Ul from '$lib/components/typo/ul.svelte';
 	import { AdultContents } from '@app';
 	import { page } from '$app/state';
+	import Tooltip from '$lib/components/tooltip/Tooltip.svelte';
+	import { EllipsisVertical, MessageSquare, Share2 } from 'lucide-svelte';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 
 	interface Props extends ReturnType<typeof $props> {
 		article: App.Request;
@@ -129,6 +132,40 @@
 				</Table.Body>
 			</Table.Root>
 		</section>
+		{#if me && article.author.id !== me.id}
+			<section class="flex">
+				<Tooltip class="w-full" text="차단했거나 차단된 경우 메시지를 보낼 수 없습니다">
+					<!-- disabled={relationshipFromUser !== UserRelationship.BLOCKED &&
+						relationshipToUser !== UserRelationship.BLOCKED} -->
+					{#snippet child({ props })}
+						<div {...props} class="w-full">
+							<Button class="w-full flex-1">
+								<!-- onclick={onBeginDM} -->
+								<!-- disabled={relationshipFromUser === UserRelationship.BLOCKED ||
+									relationshipToUser === UserRelationship.BLOCKED ||
+									user.id === me?.id} -->
+								<MessageSquare />
+								이 의뢰에 관해 메시지하기
+							</Button>
+						</div>
+					{/snippet}
+				</Tooltip>
+				<Button size="icon" variant="outline"><Share2 /></Button>
+				<!--  onclick={onCopyProfileLink} -->
+				<!-- TODO 구현 완료 시 재활성화
+				<DropdownMenu.Root>
+					<DropdownMenu.Trigger class="m-0 p-0">
+						{#snippet child({ props })}
+							<Button {...props} variant="outline" size="icon"><EllipsisVertical /></Button>
+						{/snippet}
+					</DropdownMenu.Trigger>
+					<DropdownMenu.Content class="w-56" align="end">
+						<DropdownMenu.Item onclick={() => {}}>신고하기</DropdownMenu.Item>
+					</DropdownMenu.Content>
+				</DropdownMenu.Root>
+						-->
+			</section>
+		{/if}
 		<section>
 			<H3>기타 정보</H3>
 			<Table.Root>

--- a/src/stories/request/View.svelte
+++ b/src/stories/request/View.svelte
@@ -18,6 +18,7 @@
 	import { EllipsisVertical, MessageSquare, Share2 } from 'lucide-svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { toast } from 'svelte-sonner';
+	import { deserialize } from '$app/forms';
 
 	interface Props extends ReturnType<typeof $props> {
 		article: App.Request;
@@ -55,6 +56,23 @@
 				description: '원하는 곳에 붙여넣어 사용하시기 바랍니다.',
 			});
 		});
+	};
+
+	// DM 시작
+	const onBeginDM = async () => {
+		const result = await fetch('?/beginDM', { method: 'post', body: new FormData() })
+			.then((r) => r.text())
+			.then((r) => deserialize(r));
+
+		if (result.type === 'success') {
+			const channelId = result.data?.channelId;
+
+			if (channelId) goto(`/dm/${channelId}`);
+		} else {
+			toast.error('사용자와의 메시지 채널 처리 도중 오류가 발생했습니다.', {
+				description: '고객센터에 문의해주시기 바랍니다.',
+			});
+		}
 	};
 </script>
 
@@ -149,8 +167,7 @@
 						relationshipToUser !== UserRelationship.BLOCKED} -->
 					{#snippet child({ props })}
 						<div {...props} class="w-full">
-							<Button class="w-full flex-1">
-								<!-- onclick={onBeginDM} -->
+							<Button class="w-full flex-1" onclick={onBeginDM}>
 								<!-- disabled={relationshipFromUser === UserRelationship.BLOCKED ||
 									relationshipToUser === UserRelationship.BLOCKED ||
 									user.id === me?.id} -->

--- a/src/stories/user/Profile.svelte
+++ b/src/stories/user/Profile.svelte
@@ -321,8 +321,6 @@
 		],
 	};
 
-	let openErrorOnBeginDM = $state(false);
-
 	const onBeginDM = async () => {
 		const result = await fetch('?/beginDM', { method: 'post', body: new FormData() })
 			.then((r) => r.text())
@@ -333,7 +331,9 @@
 
 			if (channelId) goto(`/dm/${channelId}`);
 		} else {
-			openErrorOnBeginDM = true;
+			toast.error('사용자와의 메시지 채널 처리 도중 오류가 발생했습니다.', {
+				description: '고객센터에 문의해주시기 바랍니다.',
+			});
 		}
 	};
 </script>
@@ -923,10 +923,6 @@
 	title="사용자 차단 해제 처리 도중 오류가 발생했습니다."
 	description="고객센터에 문의해주시기 바랍니다."
 	bind:open={openErrorOnUnblock} />
-<AlertDialog
-	title="사용자와의 메시지 채널 처리 도중 오류가 발생했습니다."
-	description="고객센터에 문의해주시기 바랍니다."
-	bind:open={openErrorOnBeginDM} />
 
 <style lang="scss">
 	:global([aria-label='color picker']) {

--- a/src/stories/user/Profile.svelte
+++ b/src/stories/user/Profile.svelte
@@ -245,11 +245,11 @@
 	let profileEditMode = $state(false);
 
 	// Profile link copy
-	let openLinkCopyAlert = $state(false);
-
 	const onCopyProfileLink = () => {
 		navigator.clipboard.writeText(location.href).then(() => {
-			openLinkCopyAlert = true;
+			toast.success('프로필 링크가 복사되었습니다.', {
+				description: '원하는 곳에 붙여넣어 사용하시기 바랍니다.',
+			});
 		});
 	};
 
@@ -891,10 +891,6 @@
 	title="프로필 업데이트 처리 도중 오류가 발생했습니다."
 	description="고객센터에 문의해주시기 바랍니다."
 	bind:open={openErrorOnProfileUpdateAlert} />
-<AlertDialog
-	title="프로필 링크가 복사되었습니다."
-	description="원하는 곳에 붙여넣어 사용하시기 바랍니다."
-	bind:open={openLinkCopyAlert} />
 
 {#snippet blockDescription()}
 	<Ul>


### PR DESCRIPTION
- resolves #82
  - 의뢰 정보 페이지에 DM, 공유 버튼 추가
    - 공유 버튼 클릭 시 URL 복사
  - 의뢰에서 DM 버튼 클릭 시 해당 게시물과 관련된 1:1 DM 채널이 없으면 생성
    - 채널 생성 시 양측의 참가 메시지 및 관련 의뢰 첨부 메시지 자동 전송
    - 차단된/차단한 경우 DM 채널 생성 불가
  - 1:1 DM 채널이 있으면 그 방으로 연결
- 기타: 기본 배경 색상을 고정
- 기타: 메인 페이지에서 게시물 목록이 수정시간 내림차순으로 정렬되지 않은 문제 해결
- 기타: 프로필 공유 완료 안내 방식을 `AlertDialog`에서 `toast`로 변경
- 기타: DM 개설 직후 대화방 페이지 접속 시 참가 메시지가 표시되지 않는 문제 해결 (임시방편)
- 기타: 다크모드에서 primary 색상 텍스트가 가독성이 떨어지는 문제 해결
- resolves #62 (부모 이슈)