### PR TITLE
#88: 이메일 인증 시 초대코드를 입력하도록 강제

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -84,4 +84,7 @@ export const searchResultsPerPage = 10;
 export const profileArticlesPerPage = 10;
 export const dmsPerPage = 20;
 
+// XXX (여기부터) 알파테스트 전용
 export const invitationCodesPerPage = 10;
+export const invitationCodeLength = 10;
+// XXX (여기까지) 알파테스트 전용

--- a/src/lib/schema/emailConfirm.ts
+++ b/src/lib/schema/emailConfirm.ts
@@ -8,6 +8,7 @@ export const formSchema = z.object({
 			'인증 코드가 잘못되었습니다. 다시 확인해주시기 바랍니다.',
 		),
 	email: z.string().email().optional(),
+	invitationCode: z.string().optional(), // XXX: 알파테스트 전용
 });
 
 export type FormSchema = typeof formSchema;

--- a/src/routes/admin/invitation/+page.server.ts
+++ b/src/routes/admin/invitation/+page.server.ts
@@ -3,7 +3,7 @@ import { desc, eq } from 'drizzle-orm';
 import type { Actions, PageServerLoad } from './$types';
 import { alias } from 'drizzle-orm/pg-core';
 import { fail } from '@sveltejs/kit';
-import { invitationCodesPerPage } from '$lib/config';
+import { invitationCodeLength, invitationCodesPerPage } from '$lib/config';
 import { UserRole } from '@app';
 
 export const load = (async () => {
@@ -47,7 +47,7 @@ export const actions: Actions = {
 
 		try {
 			await db.insert(table.invitationCode).values({
-				code: generateID(10),
+				code: generateID(invitationCodeLength),
 				createdBy: locals.user.id,
 			});
 

--- a/src/routes/register/email-confirm/+page.server.ts
+++ b/src/routes/register/email-confirm/+page.server.ts
@@ -21,6 +21,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 export const actions: Actions = {
 	send: async (event) => {
+		// TODO 1차 알파테스트 전용: 입력받은 초대코드가 유효한지 확인
+
 		const confirmCode = mailauth.generateConfirmCode();
 		const sessionToken = mailauth.generateSessionToken();
 
@@ -69,7 +71,10 @@ export const actions: Actions = {
 
 			await db
 				.update(table.user)
-				.set({ status: UserStatus.NOT_AUTHENTICATED })
+				.set({
+					status: UserStatus.NOT_AUTHENTICATED,
+					invitationCode: form.data.invitationCode, // XXX: 알파테스트 전용
+				})
 				.where(eq(table.user.id, emailConfirm.userId));
 		} catch (e: any) {
 			console.error(e);

--- a/src/routes/register/email-confirm/+page.server.ts
+++ b/src/routes/register/email-confirm/+page.server.ts
@@ -19,9 +19,42 @@ export const load: PageServerLoad = async ({ locals }) => {
 	};
 };
 
+// XXX (여기부터) 알파테스트 전용
+const checkInvitationCode = async (invitationCode: string | null) => {
+	if (!invitationCode) throw new Error('Invitation code is required', { cause: 400 });
+
+	const invitationCodeRecord = (
+		await db
+			.select()
+			.from(table.invitationCode)
+			.where(eq(table.invitationCode.code, invitationCode))
+	).at(0);
+
+	if (!invitationCodeRecord) throw new Error('Invalid invitation code', { cause: 404 });
+
+	const invitationCodeUser = (
+		await db
+			.select({ invitationCode: table.user.invitationCode })
+			.from(table.user)
+			.where(eq(table.user.invitationCode, invitationCode))
+	).at(0);
+
+	if (invitationCodeUser) throw new Error('Invalid invitation code', { cause: 404 });
+};
+// XXX (여기까지) 알파테스트 전용
+
 export const actions: Actions = {
 	send: async (event) => {
-		// TODO 1차 알파테스트 전용: 입력받은 초대코드가 유효한지 확인
+		// XXX (여기부터) 알파테스트 전용
+		const invitationCode = (await event.request.formData()).get('invitation_code') as string | null;
+
+		try {
+			await checkInvitationCode(invitationCode);
+		} catch (e) {
+			if (e instanceof Error && typeof e.cause === 'number')
+				return fail(e.cause, { message: e.message });
+		}
+		// XXX (여기까지) 알파테스트 전용
 
 		const confirmCode = mailauth.generateConfirmCode();
 		const sessionToken = mailauth.generateSessionToken();
@@ -37,6 +70,13 @@ export const actions: Actions = {
 			);
 
 			mailauth.setSessionTokenCookie(event, sessionToken, session.expiresAt);
+
+			// XXX (여기부터) 알파테스트 전용
+			event.cookies.set('email-confirm-invitation-code', invitationCode!, {
+				expires: session.expiresAt,
+				path: '/',
+			});
+			// XXX (여기까지) 알파테스트 전용
 
 			return {
 				message: 'Email sent',
@@ -54,6 +94,17 @@ export const actions: Actions = {
 		if (!form.valid) {
 			return fail(400, { message: 'The form is not valid.', form });
 		}
+
+		// XXX (여기부터) 알파테스트 전용
+		const invitationCode = event.cookies.get('email-confirm-invitation-code') || null;
+
+		try {
+			await checkInvitationCode(invitationCode);
+		} catch (e) {
+			if (e instanceof Error && typeof e.cause === 'number')
+				return fail(e.cause, { message: e.message });
+		}
+		// XXX (여기까지) 알파테스트 전용
 
 		const sessionToken = event.cookies.get(mailauth.sessionCookieName);
 		if (!sessionToken) {
@@ -73,7 +124,7 @@ export const actions: Actions = {
 				.update(table.user)
 				.set({
 					status: UserStatus.NOT_AUTHENTICATED,
-					invitationCode: form.data.invitationCode, // XXX: 알파테스트 전용
+					invitationCode: invitationCode, // XXX 알파테스트 전용
 				})
 				.where(eq(table.user.id, emailConfirm.userId));
 		} catch (e: any) {

--- a/src/stories/register/EmailConfirm.svelte
+++ b/src/stories/register/EmailConfirm.svelte
@@ -90,6 +90,7 @@
 		if (confirmFor === EmailConfirmFor.RESET_PASSWORD) {
 			formData.append('email', email);
 		}
+		// TODO 1차 알파테스트: 가입 시 확인 이메일 전송 요청 시 초대코드도 전달
 
 		const result = await fetch('?/send', {
 			method: 'post',
@@ -130,7 +131,7 @@
 	<P>{descriptions.desc}</P>
 	<form method="POST" class="w-full sm:w-2/3" action="?/do" use:enhance>
 		{#if confirmFor === EmailConfirmFor.RESET_PASSWORD}
-			<Form.Field {form} name="email" class="flex flex-col my-4 space-y-1">
+			<Form.Field {form} name="email" class="my-4 flex flex-col space-y-1">
 				<Form.Control>
 					{#snippet children({ props })}
 						<Form.Label>비밀번호를 재설정할 이메일 주소</Form.Label>
@@ -144,14 +145,18 @@
 				</Form.Control>
 				<Form.FieldErrors />
 			</Form.Field>
+			<!-- XXX: (여기부터) 알파테스트 전용 -->
+		{:else if confirmFor === EmailConfirmFor.REGISTRATION}
+			<!-- TODO 1차 알파테스트: 초대코드 입력란 추가 -->
+			<!-- XXX: (여기까지) 알파테스트 전용 -->
 		{/if}
-		<div class="flex flex-col my-4 space-y-1">
-			<div class="text-sm font-medium leading-none">
+		<div class="my-4 flex flex-col space-y-1">
+			<div class="text-sm leading-none font-medium">
 				아래 버튼을 클릭하여 인증 메일을 보낸 뒤, 메일에 기재된 인증 코드를 입력해주세요.
 			</div>
 		</div>
 		<Button onclick={onSend} disabled={expiresIn === -1}>인증메일 보내기</Button>
-		<Form.Field {form} name="confirmCode" class="flex flex-col my-4 space-y-1">
+		<Form.Field {form} name="confirmCode" class="my-4 flex flex-col space-y-1">
 			<Form.Control>
 				{#snippet children({ props })}
 					<Form.Label>

--- a/src/stories/register/EmailConfirm.svelte
+++ b/src/stories/register/EmailConfirm.svelte
@@ -15,6 +15,7 @@
 	import Ul from '$lib/components/typo/ul.svelte';
 	import Header from '$stories/components/Header.svelte';
 	import AlertDialog from '$stories/components/AlertDialog.svelte';
+	import { toast } from 'svelte-sonner';
 
 	interface Props {
 		data: SuperValidated<Infer<FormSchema>>;
@@ -78,9 +79,9 @@
 	};
 
 	let email = $state('');
+	let invitationCode = $state(''); // XXX 알파테스트 전용
 
 	let openUserNotFoundAlert = $state(false);
-	let openSendErrorAlert = $state(false);
 
 	const onSend = async () => {
 		const formData = new FormData();
@@ -89,8 +90,12 @@
 
 		if (confirmFor === EmailConfirmFor.RESET_PASSWORD) {
 			formData.append('email', email);
+			// XXX (여기부터) 알파테스트 전용
+		} else if (confirmFor === EmailConfirmFor.REGISTRATION) {
+			// 1차 알파테스트: 가입 시 확인 이메일 전송 요청 시 초대코드도 전달
+			formData.append('invitation_code', invitationCode);
+			// XXX (여기까지) 알파테스트 전용
 		}
-		// TODO 1차 알파테스트: 가입 시 확인 이메일 전송 요청 시 초대코드도 전달
 
 		const result = await fetch('?/send', {
 			method: 'post',
@@ -98,8 +103,19 @@
 		}).then((r) => r.json());
 
 		if ([200, 204, 302].indexOf(result.status || 0) === -1) {
-			if (result.status === 404) openUserNotFoundAlert = true;
-			else openSendErrorAlert = true;
+			if (result.status === 404) {
+				// XXX (여기부터) 알파테스트 전용
+				if (confirmFor === EmailConfirmFor.REGISTRATION) {
+					toast.error('초대코드가 잘못되었습니다.', {
+						description: '다시 확인하시거나 관리자에게 문의하시기 바랍니다.',
+					});
+				} else
+					// XXX (여기까지) 알파테스트 전용
+					openUserNotFoundAlert = true;
+			} else
+				toast.error('인증메일을 보내는 도중 오류가 발생했습니다.', {
+					description: '고객센터에 문의해주시기 바랍니다.',
+				});
 			expiresIn = 0;
 			return;
 		}
@@ -140,6 +156,7 @@
 							placeholder="이메일 주소"
 							bind:value={email}
 							{...$constraints.email}
+							disabled={expiresIn > 0 || expiresIn === -1}
 							required />
 					{/snippet}
 				</Form.Control>
@@ -147,7 +164,26 @@
 			</Form.Field>
 			<!-- XXX: (여기부터) 알파테스트 전용 -->
 		{:else if confirmFor === EmailConfirmFor.REGISTRATION}
-			<!-- TODO 1차 알파테스트: 초대코드 입력란 추가 -->
+			<!-- 1차 알파테스트: 초대코드 입력란 추가 -->
+			<Form.Field {form} name="invitationCode" class="my-4 flex flex-col space-y-1">
+				<Form.Control>
+					{#snippet children({ props })}
+						<Form.Label>초대코드</Form.Label>
+						<Input
+							{...props}
+							placeholder="초대코드"
+							bind:value={invitationCode}
+							{...$constraints.invitationCode}
+							disabled={expiresIn > 0 || expiresIn === -1}
+							required />
+					{/snippet}
+				</Form.Control>
+				<Form.Description>
+					알파테스트 기간 중에는 관리자로부터 초대코드를 발급받아야 합니다. 아직 발급받지 않은 경우
+					관리자에게 문의하시기 바랍니다.
+				</Form.Description>
+				<Form.FieldErrors />
+			</Form.Field>
 			<!-- XXX: (여기까지) 알파테스트 전용 -->
 		{/if}
 		<div class="my-4 flex flex-col space-y-1">
@@ -186,7 +222,3 @@
 	title="이메일 인증 처리 도중 오류가 발생했습니다."
 	description="고객센터에 문의해주시기 바랍니다."
 	bind:open={openOtherErrorAlert} />
-<AlertDialog
-	title="인증메일을 보내는 도중 오류가 발생했습니다."
-	description="고객센터에 문의해주시기 바랍니다."
-	bind:open={openSendErrorAlert} />


### PR DESCRIPTION
- resolves #88
  - 초대코드가 올바른 경우 인증 메일 전송
  - 이메일 인증 완료 시 초대코드 연결
- 기타: 초대코드 길이를 설정 파일에 저장
- resolves #65 (부모 이슈)